### PR TITLE
feat: implement build command [CC-1115]

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/snyk/snyk-iac-custom-rules/internal"
+	"github.com/snyk/snyk-iac-custom-rules/util"
+)
+
+var BuildIgnore = append(TestIgnore, "*_test.rego")
+
+var buildCommand = &cobra.Command{
+	Use:   "build <path>",
+	Short: "Build an OPA WASM bundle",
+	Long: `Build an OPA WASM bundle.
+
+The 'build' command packages OPA policy and data files into gzipped tarballs containing policies and data written as WASM.
+`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Building OPA WASM bundle...")
+		if len(args) == 0 {
+			args = append(args, "./")
+		}
+		err := internal.RunBuild(args, buildParams)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Bundle %s has been generated\n", buildParams.OutputFile)
+		return nil
+	},
+}
+
+func newBuildCommandParams() *internal.BuildCommandParams {
+	return &internal.BuildCommandParams{
+		Entrypoint: util.NewRepeatedStringFlag("rules/deny"),
+		Target:     util.NewEnumFlag(internal.TargetWasm, []string{internal.TargetRego, internal.TargetWasm}),
+	}
+}
+
+var buildParams = newBuildCommandParams()
+
+func init() {
+	buildCommand.Flags().VarP(&buildParams.Entrypoint, "entrypoint", "e", "set slash separated entrypoint path")
+	buildCommand.Flags().StringVarP(&buildParams.OutputFile, "output", "o", "bundle.tar.gz", "set the output filename")
+	buildCommand.Flags().StringSliceVarP(&buildParams.Ignore, "ignore", "", BuildIgnore, "set file and directory names to ignore during loading (e.g., '.*' excludes hidden files)")
+	buildCommand.Flags().VarP(&buildParams.Target, "target", "t", "set the output bundle target type")
+	RootCommand.AddCommand(buildCommand)
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/snyk/snyk-iac-custom-rules/util"
 )
 
+var TestIgnore = []string{
+	".*",
+}
+
 var testCommand = &cobra.Command{
 	Use:   "test <path>",
 	Short: "Execute Rego test cases",

--- a/internal/build.go
+++ b/internal/build.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/open-policy-agent/opa/compile"
+	"github.com/snyk/snyk-iac-custom-rules/util"
+)
+
+const (
+	TargetRego = "rego"
+	TargetWasm = "wasm"
+)
+
+type BuildCommandParams struct {
+	Entrypoint util.RepeatedStringFlag
+	OutputFile string
+	Ignore     []string
+	Target     util.EnumFlag
+}
+
+func RunBuild(args []string, params *BuildCommandParams) error {
+	buf := bytes.NewBuffer(nil)
+
+	compiler := compile.New().
+		WithTarget(params.Target.String()).
+		WithAsBundle(false).
+		WithOutput(buf).
+		WithEntrypoints(params.Entrypoint.Strings()...).
+		WithPaths(args...).
+		WithFilter(buildCommandLoaderFilter(false, params.Ignore))
+
+	err := compiler.Build(context.Background())
+	if err != nil {
+		return err
+	}
+
+	out, err := os.Create(params.OutputFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(out, buf)
+	if err != nil {
+		return err
+	}
+
+	return out.Close()
+}
+
+func buildCommandLoaderFilter(bundleMode bool, ignore []string) func(string, os.FileInfo, int) bool {
+	return func(abspath string, info os.FileInfo, depth int) bool {
+		if !info.IsDir() && strings.HasSuffix(abspath, ".tar.gz") {
+			return true
+		}
+		return util.LoaderFilter{Ignore: ignore}.Apply(abspath, info, depth)
+	}
+}

--- a/spec/build_spec.sh
+++ b/spec/build_spec.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+Describe 'go run main.go build ./fixtures/custom-rules' --ignore testing --ignore "*_test.rego"
+   It 'returns passing test status'
+      When call go run main.go build ./fixtures/custom-rules --ignore testing --ignore "*_test.rego"
+      The status should be success
+      The output should include 'Building OPA WASM bundle...'
+   End
+End

--- a/spec/help_spec.sh
+++ b/spec/help_spec.sh
@@ -9,6 +9,7 @@ Usage:
   snyk-iac-custom-rules [command]
 
 Available Commands:
+  build       Build an OPA WASM bundle
   completion  generate the autocompletion script for the specified shell
   help        Help about any command
   test        Execute Rego test cases

--- a/util/repeated_string_flag.go
+++ b/util/repeated_string_flag.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"strings"
+)
+
+type RepeatedStringFlag struct {
+	vs           []string
+	isSet        bool
+	defaultValue string
+}
+
+func NewRepeatedStringFlag(defaultValue string) RepeatedStringFlag {
+	f := RepeatedStringFlag{
+		vs:           []string{},
+		isSet:        true,
+		defaultValue: defaultValue,
+	}
+	return f
+}
+
+func (f *RepeatedStringFlag) Type() string {
+	return "string"
+}
+
+func (f *RepeatedStringFlag) String() string {
+	if len(f.vs) == 0 {
+		return f.defaultValue
+	}
+	return strings.Join(f.vs, ",")
+}
+
+func (f *RepeatedStringFlag) Strings() []string {
+	if len(f.vs) == 0 {
+		return []string{f.defaultValue}
+	}
+	return f.vs
+}
+
+func (f *RepeatedStringFlag) Set(s string) error {
+	f.vs = append(f.vs, s)
+	f.isSet = true
+	return nil
+}
+
+func (f *RepeatedStringFlag) IsSet() bool {
+	return f.isFlagSet()
+}
+
+func (f *RepeatedStringFlag) isFlagSet() bool {
+	return f.isSet
+}


### PR DESCRIPTION
### What this does

This PR implements the `build` command, with the following optional flags:
- `--entrypoint` (same as the OPA binary)
- `--ignore` (same as the OPA binary)
- `--output` (same as the OPA binary)
- `--target` (same as the OPA binary)
Optionally, you can provide the path but if not, it's set to the current running directory by default.

Will cover error handling in a future PR.

### Notes for the reviewer

To test this, clone https://github.com/snyk/custom-rules-example, build the binary and then run `./synk-iac-custom-rules build`

The implementation has some very basic e2e tests written in shellspec - they cover generating a bundle. Further testing will be covered in future PRs, but this was added for sanity checking. 

### More information

- [Jira ticket CC-1115](https://snyksec.atlassian.net/browse/CC-1115)
- [Link to documentation](https://www.notion.so/snyk/Feature-Documentation-ab4c7d99e92948d294e04e90b537df8e)

