### PR TITLE
feat: implement template command [CC-1135]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
   regression-test:
     <<: *defaults
     docker:
-      - image: circleci/golang:1.15-node
+      - image: circleci/golang:1.16-node
     steps:
       - checkout
       - install_shellspec

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This is a Golang CLI that will provide flags for writing, debugging, testing, an
 ### Running Locally
 
 Environment preparation
-* Install [Go](https://golang.org/doc/install)
+* Install [Go](https://golang.org/doc/install) - requires Golang v1.16 at least
 * VSCode - Extentions - [Go](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go), [Open Policy Agent](https://marketplace.visualstudio.com/items?itemName=tsandall.opa)
 * Install [golangci-lint](https://github.com/golangci/golangci-lint)
 

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/snyk/snyk-iac-custom-rules/internal"
+)
+
+var templateCommand = &cobra.Command{
+	Use:   "template <path>",
+	Short: "Template a new rule",
+	Long: `Template a new rule.
+
+The 'template' command generates some templating code for writing new rules.
+`,
+	SilenceUsage: true,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Templating rule...")
+		if len(args) == 0 {
+			args = append(args, "./")
+		}
+		err := internal.RunTemplate(args, templateParams)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Generated template")
+		return nil
+	},
+}
+
+func newTemplateCommandParams() *internal.TemplateCommandParams {
+	return &internal.TemplateCommandParams{}
+}
+
+var templateParams = newTemplateCommandParams()
+
+func init() {
+	templateCommand.Flags().StringVarP(&templateParams.Rule, "rule", "r", "", "provide rule name")
+	templateCommand.MarkFlagRequired("rule") //nolint
+	RootCommand.AddCommand(templateCommand)
+}

--- a/internal/template.go
+++ b/internal/template.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/snyk/snyk-iac-custom-rules/util"
+)
+
+type TemplateCommandParams struct {
+	Rule string
+}
+
+func RunTemplate(args []string, params *TemplateCommandParams) error {
+	currentDirectory, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	workingDirectory := path.Join(currentDirectory, args[0])
+
+	templating := util.Templating{
+		RuleName: params.Rule,
+		Replace:  strings.ReplaceAll,
+	}
+	err = templateRule(workingDirectory, templating)
+	if err != nil {
+		return err
+	}
+
+	return templateLib(workingDirectory, templating)
+}
+
+func templateRule(workingDirectory string, templating util.Templating) error {
+	rulesDir, err := util.CreateDirectory(workingDirectory, "rules", false)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Templated directory %s\n", rulesDir)
+
+	ruleDir, err := util.CreateDirectory(rulesDir, templating.RuleName, true)
+	if err != nil {
+		if strings.Contains(err.Error(), "Directory already exists") {
+			return errors.New("Rule with the provided name already exists")
+		}
+		return err
+	}
+	fmt.Printf("Templated directory %s\n", ruleDir)
+
+	err = util.TemplateFile(ruleDir, "main.rego", "templates/main.tpl.rego", templating)
+	if err != nil {
+		return err
+	}
+
+	err = util.TemplateFile(ruleDir, "main_test.rego", "templates/main_test.tpl.rego", templating)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func templateLib(workingDirectory string, templating util.Templating) error {
+	libDir, err := util.CreateDirectory(workingDirectory, "lib", true)
+	if err != nil {
+		if strings.Contains(err.Error(), "Directory already exists at") {
+			return nil
+		}
+		return err
+	}
+	fmt.Printf("Templated directory %s\n", libDir)
+
+	err = util.TemplateFile(libDir, "main.rego", "templates/lib/main.tpl.rego", templating)
+	if err != nil {
+		return err
+	}
+
+	testingDir, err := util.CreateDirectory(libDir, "testing", true)
+	if err != nil {
+		if strings.Contains(err.Error(), "Directory already exists at") {
+			return nil
+		}
+		return err
+	}
+	fmt.Printf("Templated directory %s\n", testingDir)
+
+	err = util.TemplateFile(testingDir, "main.rego", "templates/lib/testing/main.tpl.rego", templating)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/spec/help_spec.sh
+++ b/spec/help_spec.sh
@@ -13,6 +13,7 @@ Available Commands:
   completion  generate the autocompletion script for the specified shell
   help        Help about any command
   parse       Parse a fixture into JSON format
+  template    Template a new rule
   test        Execute Rego test cases
 
 Flags:

--- a/spec/template_spec.sh
+++ b/spec/template_spec.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+cleanup() { rm -rf ./fixtures/custom-rules/rules/test; }
+AfterAll 'cleanup'
+
+Describe 'go run main.go template ./fixtures/custom-rules --rule test'
+   It 'returns passing test status'
+      When call go run main.go template ./fixtures/custom-rules --rule test
+      The status should be success
+      The output should include 'Templating rule...'
+      The output should include 'Templated directory'
+      The output should include '/fixtures/custom-rules/rules'
+      The output should include 'Templated directory'
+      The output should include '/fixtures/custom-rules/rules/test'
+      The output should include 'Templated file'
+      The output should include '/fixtures/custom-rules/rules/test/main.rego'
+      The output should include 'Templated file'
+      The output should include '/fixtures/custom-rules/rules/test/main_test.rego'
+   End
+End
+
+Describe 'go run main.go template ./fixtures/custom-rules --rule test'
+   It 'returns passing test status'
+      When call go run main.go template ./fixtures/custom-rules --rule test
+      The status should be failure
+      The output should include 'Templating rule...'
+      The output should include 'Rule with the provided name already exists'
+      The stderr should be present
+   End
+End

--- a/util/file_system.go
+++ b/util/file_system.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+func CreateDirectory(workingDirectory string, name string, strict bool) (string, error) {
+	dirName := path.Join(workingDirectory, name)
+	_, err := os.Stat(dirName)
+	if os.IsNotExist(err) {
+		if err := os.Mkdir(dirName, 0755); err != nil {
+			return "", err
+		}
+	} else if strict {
+		return "", fmt.Errorf("Directory already exists at path %s", dirName)
+	}
+	return dirName, nil
+}
+
+func CreateFile(workingDirectory string, name string) (string, error) {
+	fileName := path.Join(workingDirectory, name)
+	file, err := os.Create(fileName)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	return fileName, nil
+}

--- a/util/templates/lib/main.tpl.rego
+++ b/util/templates/lib/main.tpl.rego
@@ -1,0 +1,50 @@
+package lib.testing
+
+import data.lib
+
+assert_response_set(result_set, test_case) {
+	total_violations := {res |
+		result := result_set[index]
+		result.publicId == test_case.publicId
+		trace(sprintf("[%s][%d] Issue msg : %s", [test_case.publicId, test_case.index, result.msg]))
+		res := index
+	}
+
+	trace(sprintf("[%s][%s] Number of issues identified: want %d, got %d", [test_case.publicId, test_case.fixture, count(test_case.want_msgs), count(total_violations)]))
+	count(total_violations) == count(test_case.want_msgs)
+
+	violation_match := {res |
+		result := total_violations[index]
+		result.msg == test_case.want_msgs[_]
+		trace(sprintf("[%s][%d] Violation msg : %s", [test_case.publicId, test_case.index, result.msg]))
+		res := index
+	}
+
+	trace(sprintf("[%s][%s] Number of issues with correct `msg` value: want %d, got %d", [test_case.publicId, test_case.fixture, count(test_case.want_msgs), count(violation_match)]))
+	count(violation_match) == count(test_case.want_msgs)
+	trace(sprintf("[%s] Fixture %d passed", [test_case.publicId, test_case.index]))
+} else = false {
+	true
+}
+
+parse_fixture_file(fixture_file) = fixture {
+	fixture := lib.normalize_to_array(yaml.unmarshal_file(fixture_file))
+}
+
+get_result_set(fixture) = result_set {
+	result_set := data.rules.deny with input as fixture
+}
+
+evaluate_test_cases(publicId, test_cases) {
+	passed_tests := {res |
+		tc := lib.merge_objects(test_cases[index], {"publicId": publicId, "index": index})
+		result_set := get_result_set(tc.fixture)
+		assert_response_set(result_set, tc)
+		res := index
+	}
+
+	trace(sprintf("[%s] Number of test cases passed: want %d, got %d", [publicId, count(test_cases), count(passed_tests)]))
+	count(passed_tests) == count(test_cases)
+} else = false {
+	true
+}

--- a/util/templates/lib/testing/main.tpl.rego
+++ b/util/templates/lib/testing/main.tpl.rego
@@ -1,0 +1,23 @@
+package lib
+
+has_field(obj, field) {
+	_ := obj[field]
+}
+
+normalize_to_array(resource) = out_array {
+	is_array(resource)
+	out_array = resource
+} else = out_array {
+	out_array = [resource]
+}
+
+pick(k, obj1, _) = obj1[k]
+
+pick(k, obj1, obj2) = obj2[k] {
+	not has_field(obj1, k)
+}
+
+merge_objects(a, b) = c {
+	keys := {k | some k; _ = a[k]} | {k | some k; _ = b[k]}
+	c := {k: v | k := keys[_]; v := pick(k, b, a)}
+}

--- a/util/templates/main.tpl.rego
+++ b/util/templates/main.tpl.rego
@@ -1,0 +1,15 @@
+package rules
+
+deny[msg] {
+	input.spec.template.todo
+	msg := {
+		"publicId": "{{.RuleName}}",
+		"title": "<TODO>",
+		"severity": "<TODO>",
+		"issue": "",
+		"impact": "",
+		"remediation": "",
+		"msg": "spec.template.todo",
+		"references": [],
+	}
+}

--- a/util/templates/main_test.tpl.rego
+++ b/util/templates/main_test.tpl.rego
@@ -1,0 +1,28 @@
+package rules
+
+import data.lib
+import data.lib.testing
+
+test_{{ call .Replace .RuleName "-" "_" }} {
+	test_cases := [{
+		"want_msgs": [],
+		"fixture": {
+			"spec": {
+				"template": {
+					"todo": false
+				}
+			}
+		},
+	}, {
+		"want_msgs": ["spec.template.todo"],
+		"fixture": {
+			"spec": {
+				"template": {
+					"todo": true
+				}
+			}
+		},
+	}]
+
+	testing.evaluate_test_cases("{{.RuleName}}", test_cases)
+}

--- a/util/templating.go
+++ b/util/templating.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+//go:embed templates/*
+//go:embed templates/lib/*
+//go:embed templates/lib/testing/*
+var templateFs embed.FS
+
+type Templating struct {
+	RuleName string
+	Replace  func(string, string, string) string
+}
+
+func TemplateFile(workingDirectory string, fileName string, template string, templating Templating) error {
+	filePath, err := CreateFile(workingDirectory, fileName)
+	if err != nil {
+		return err
+	}
+	err = generateTemplate(filePath, template, templating)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Templated file %s\n", filePath)
+	return nil
+}
+
+func generateTemplate(fileName string, templateFile string, templating Templating) error {
+	tpl, err := template.ParseFS(templateFs, templateFile)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+	return tpl.Execute(file, templating)
+}


### PR DESCRIPTION
### What this does

This PR implements the `template` command, with the following required flag:
- `--rule`
An optional path can be provided, but if it isn't it defaults to `./`. The command does rule templating, together with helper testing functions.

Will cover error handling in a future PR.

### Notes for the reviewer

To test, run:
- `go run main.go template ./fixtures/custom-rules --rule test`
- `go run main.go template ./fixtures/custom-rules --rule test`
- `go run main.go template ./fixtures/custom-rules --rule another_test`

The command sees if a rule was created already and if so, errors. If not, then it creates the folder with the templated rego code. Then, it sees if the helper functions under the `lib` and `lib/testing` folders have been created in a previous run or by the customer themselves. If so, it doesn't do anything. But if not, it generates those folders and the rego helper functions inside them, so that the customer can easily start testing their rules.

### More information

- [Jira ticket CC-1135](https://snyksec.atlassian.net/browse/CC-1135)
- [Link to documentation](https://www.notion.so/snyk/Feature-Documentation-ab4c7d99e92948d294e04e90b537df8e)

