### PR TITLE
chore: Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Snyk IaC Custom Rules
 
-[![CircleCI](https://circleci.com/gh/snyk/snyk-iac-custom-rules/tree/develop.svg?style=svg)](https://circleci.com/gh/snyk/snyk-iac-custom-rules/tree/develop)
+[![CircleCI](https://circleci.com/gh/snyk/snyk-iac-custom-rules/tree/develop.svg?style=svg&circle-token=5597b9f0189554f754f38400cbe9d8f8b334c72a)](https://circleci.com/gh/snyk/snyk-iac-custom-rules/tree/develop) [![Shellspec Tests](https://github.com/snyk/snyk-iac-custom-rules/actions/workflows/main.yml/badge.svg)](https://github.com/snyk/snyk-iac-custom-rules/actions/workflows/main.yml)
 
 This is a Golang CLI that will provide flags for writing, debugging, testing, and bundling a customer's custom rules for the Snyk IaC CLI.
 


### PR DESCRIPTION
### What this does

Fixes a spelling. Also adds a suggestion on running the `go run main.go .` directly if people are not familiar with go. The go run will not produce an executable so users will have to run the subcommand, e.g. `go run main.go template` 

Also fixes the status badges icon by providing an API token for the private repo.
![image](https://user-images.githubusercontent.com/6989529/132549275-7d2907ee-3ae1-4546-bbf5-43f9ac123327.png)
