### PR TITLE
chore: update circleci and CI/CD process [CC-1130]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,7 @@
 version: 2.1
 
-orbs:
-  win: circleci/windows@2.4.1
-
 defaults: &defaults
   working_directory: ~/snyk-iac-custom-rules
-
-windows_defaults: &windows_defaults
-  executor:
-    name: win/default
-    shell: powershell.exe
 
 macos_defaults: &macos_defaults
   macos:
@@ -22,47 +14,16 @@ commands:
       - run: curl -fsSL https://git.io/shellspec | sh -s -- -y
       - run: sudo ln -s ${HOME}/.local/lib/shellspec/shellspec /usr/local/bin/shellspec
       - run: sudo apt-get install jq
-  install_golang:
-    description: Install Golang in Windows
-    steps:
-    - run:
-        name: Install
-        command: |
-          $downloadDir = $env:TEMP
-          $version = "1.16.1"
-          $url = 'https://storage.googleapis.com/golang/go' + $version + '.windows-amd64.zip'
-          $goroot = "C:\go$version"
-
-          echo "Downloading $url"
-          $zip = "$downloadDir\golang-$version.zip"
-          if (!(Test-Path "$zip")) {
-            $downloader = new-object System.Net.WebClient
-            $downloader.DownloadFile($url, $zip)
-          }
-
-          echo "Extracting $zip to $goroot"
-          if (Test-Path "$downloadDir\go") {
-            rm -Force -Recurse -Path "$downloadDir\go"
-          }
-          Add-Type -AssemblyName System.IO.Compression.FileSystem
-          [System.IO.Compression.ZipFile]::ExtractToDirectory("$zip", $downloadDir)
-          mv "$downloadDir\go" $goroot
-
-          echo "Setting GOROOT and PATH for Machine"
-          [System.Environment]::SetEnvironmentVariable("GOROOT", "$goroot", "Machine")
-          $p = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-          $p = "$goroot\bin;$p"
-          [System.Environment]::SetEnvironmentVariable("PATH", "$p", "Machine")
   build:
     description: Build Golang CLI
     steps:
       - run:
           name: Build
-          command: go build -o synk-iac-custom-rules .
+          command: go build -o snyk-iac-custom-rules .
       - persist_to_workspace:
-          root: .
+          root: ./ # relative to the working directory
           paths:
-            - synk-iac-custom-rules
+            - snyk-iac-custom-rules # the file we want to store
 
 jobs:
   lint_and_format:
@@ -101,55 +62,6 @@ jobs:
       - run:
           name: Run Golang tests
           command: go test
-  test-windows:
-    <<: *defaults
-    <<: *windows_defaults
-    steps:
-      - checkout
-      - install_golang
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
-      - run:
-          name: Run sanity test
-          command: go version; go run main.go
-      - save_cache:
-          key: go-mod-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
-  test-macos:
-    <<: *defaults
-    <<: *macos_defaults
-    steps:
-      - checkout
-      - run:
-          name: Run sanity test
-          command: |
-            sudo mkdir -p /usr/local/go
-            sudo chown -R $(whoami): /usr/local/go
-            curl -sSL "https://dl.google.com/go/go1.16.darwin-amd64.tar.gz" | sudo tar -xz -C /usr/local/
-            export PATH=$PATH:/usr/local/go/bin 
-
-            go version
-
-            go run main.go
-  test-linux:
-    <<: *defaults
-    docker:
-      - image: circleci/golang:1.16-node
-    resource_class: small
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
-      - run:
-          name: Run sanity test
-          command: go run main.go
-      - save_cache:
-          key: go-mod-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
 
 workflows:
   version: 2
@@ -167,18 +79,3 @@ workflows:
             branches:
               ignore:
                 - main
-      - test-windows:
-          name: Windows
-          requires:
-            - Lint & formatting
-            - Regression Test
-      - test-linux:
-          name: Linux
-          requires:
-            - Lint & formatting
-            - Regression Test
-      - test-macos:
-          name: MacOS
-          requires:
-            - Lint & formatting
-            - Regression Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Shellspec Tests
 
 on:
   push:
+    branches:
+      - '*'
+      - '!main'
 
 jobs:
   smoke_test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-synk-iac-custom-rules
+snyk-iac-custom-rules
 .DS_Store
+bundle.tar.gz

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ ./snyk-iac-custom-rules
 
 ### Testing
 
+Make sure to build the Golang binary first by running `go build -o snyk-iac-custom-rules .`.
 From the project's root folder, run `shellspec` to run [shellspec](https://github.com/shellspec/shellspec) tests.
 
 ### Formatting & Linting

--- a/spec/build_spec.sh
+++ b/spec/build_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-Describe 'go run main.go build ./fixtures/custom-rules' --ignore testing --ignore "*_test.rego"
+Describe './snyk-iac-custom-rules build ./fixtures/custom-rules' --ignore testing --ignore "*_test.rego"
    It 'returns passing test status'
-      When call go run main.go build ./fixtures/custom-rules --ignore testing --ignore "*_test.rego"
+      When call ./snyk-iac-custom-rules build ./fixtures/custom-rules --ignore testing --ignore "*_test.rego"
       The status should be success
       The output should include 'Building OPA WASM bundle...'
    End

--- a/spec/help_spec.sh
+++ b/spec/help_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-Describe 'go run main.go'
+Describe './snyk-iac-custom-rules'
    It 'returns help info'
-      When call go run main.go
+      When call ./snyk-iac-custom-rules
       The status should be success
       The output should include 'An SDK to write, debug, test, and bundle custom rules for Snyk IaC.
 

--- a/spec/parse_spec.sh
+++ b/spec/parse_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-Describe 'go run main.go parse ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/test.tf'
+Describe './snyk-iac-custom-rules parse ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/test.tf'
    It 'returns passing test status'
-      When call go run main.go parse ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/test.tf
+      When call ./snyk-iac-custom-rules parse ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/test.tf
       The status should be success
       The output should include '{
 	"resource": {
@@ -25,9 +25,9 @@ Describe 'go run main.go parse ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/t
    End
 End
 
-Describe 'go run main.go parse ./fixtures/custom-rules/rules/CUSTOM-3/fixtures/test.yaml --format yaml'
+Describe './snyk-iac-custom-rules parse ./fixtures/custom-rules/rules/CUSTOM-3/fixtures/test.yaml --format yaml'
    It 'returns passing test status'
-      When call go run main.go parse ./fixtures/custom-rules/rules/CUSTOM-3/fixtures/test.yaml --format yaml
+      When call ./snyk-iac-custom-rules parse ./fixtures/custom-rules/rules/CUSTOM-3/fixtures/test.yaml --format yaml
       The status should be success
       The output should include '{
 	"apiVersion": "v1",

--- a/spec/template_spec.sh
+++ b/spec/template_spec.sh
@@ -3,9 +3,9 @@
 cleanup() { rm -rf ./fixtures/custom-rules/rules/test; }
 AfterAll 'cleanup'
 
-Describe 'go run main.go template ./fixtures/custom-rules --rule test'
+Describe './snyk-iac-custom-rules template ./fixtures/custom-rules --rule test'
    It 'returns passing test status'
-      When call go run main.go template ./fixtures/custom-rules --rule test
+      When call ./snyk-iac-custom-rules template ./fixtures/custom-rules --rule test
       The status should be success
       The output should include 'Templating rule...'
       The output should include 'Templated directory'
@@ -19,9 +19,9 @@ Describe 'go run main.go template ./fixtures/custom-rules --rule test'
    End
 End
 
-Describe 'go run main.go template ./fixtures/custom-rules --rule test'
+Describe './snyk-iac-custom-rules template ./fixtures/custom-rules --rule test'
    It 'returns passing test status'
-      When call go run main.go template ./fixtures/custom-rules --rule test
+      When call ./snyk-iac-custom-rules template ./fixtures/custom-rules --rule test
       The status should be failure
       The output should include 'Templating rule...'
       The output should include 'Rule with the provided name already exists'

--- a/spec/test_spec.sh
+++ b/spec/test_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-Describe 'go run main.go test ./fixtures/custom-rules'
+Describe './snyk-iac-custom-rules test ./fixtures/custom-rules'
    It 'returns passing test status'
-      When call go run main.go test ./fixtures/custom-rules
+      When call ./snyk-iac-custom-rules test ./fixtures/custom-rules
       The status should be success
       The output should include 'Executing Rego test cases...
 PASS: 3/3'


### PR DESCRIPTION
### What this does

This PR updates the CI/CD process so that the `shellspec` tests run the generated binary, CircleCi doesn't run unnecessary tests in Windows/Linux/MacOS (we already do that in the GitHub action), and the CI/CD is split by pipeline (feature branch, `develop`, `main`).

### Notes for the reviewer

This is in preparation for adding the release process. The new CI/CD process is:
- PR from feature branch to `develop`: runs the CircleCI test pipeline and shellspec GitHub Action
- `develop`: runs the shellspec GitHub Action
- PR from `develop` to `main`: runs the shellspec GitHub Action
- `main`: runs the release CircleCI pipeline (to come in a future PR)

### More information

- [Jira ticket CC-1130](https://snyksec.atlassian.net/browse/CC-1130)

