### PR TITLE
chore: add goreleaser release process [CC-1130]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,6 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/snyk-iac-custom-rules
 
-macos_defaults: &macos_defaults
-  macos:
-    xcode: 11.3.0
-
 commands:
   install_shellspec:
     description: Install Shellspec
@@ -73,9 +69,11 @@ workflows:
             branches:
               ignore:
                 - main
+                - develop
       - regression-test:
           name: Regression Test
           filters:
             branches:
               ignore:
                 - main
+                - develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release SDK
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  release:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Push a new GitHub tag
+        run: ./scripts/increment-release-tag.sh ${GITHUB_SHA}
+
+      - name: Push a new GitHub release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 snyk-iac-custom-rules
 .DS_Store
 bundle.tar.gz
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,94 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./main.go
+    env:
+    - CGO_ENABLED=0
+    goos:
+    - windows
+    - linux
+    - darwin
+    goarch:
+    - amd64
+    - arm64
+
+archives:
+  - id: default
+    files:
+      - none*
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format: tar.gz
+    format_overrides:
+    - goos: windows
+      format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - '^chore:'
+    - '^refactor:'
+    - '^Merge pull request'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+release:
+  # If set to true, will not auto-publish the release.
+  draft: false
+
+  # Header template for the release body.
+  # Defaults to empty.
+  header: |
+    ## snyk-iac-custom-rules ({{ .Date }})
+
+    Welcome to this new release!
+
+  # Footer template for the release body.
+  # Defaults to empty.
+  footer: |
+    ## Thanks!
+
+    Those were the changes on {{ .Tag }}!
+
+brews:
+  -
+    # If set to auto, the release will not be uploaded to the homebrew tap
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+    # Default is false.
+    skip_upload: true
+
+scoop:
+  # If set to auto, the release will not be uploaded to the scoop bucket
+  # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+  # Default is false.
+  skip_upload: true
+
+dockers:
+  -
+    # If set to auto, the release will not be pushed to the Docker repository
+    #  in case there is an indicator of a prerelease in the tag, e.g. v1.0.0-rc1.
+    #
+    # Defaults to false.
+    skip_push: false
+
+announce:
+  twitter:
+    enabled: false
+  slack:
+    enabled: false
+  reddit:
+    enabled: false

--- a/scripts/increment-release-tag.sh
+++ b/scripts/increment-release-tag.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+GIT_COMMIT="$1"
+
+LATEST_TAG_WITH_V=$(git describe --tags $(git rev-list --tags --max-count=1))
+LATEST_TAG=${LATEST_TAG_WITH_V:1}
+
+IFS=. SPLIT_LATEST_TAG=(${LATEST_TAG##*-})
+MAJOR=${SPLIT_LATEST_TAG[0]}
+MINOR=${SPLIT_LATEST_TAG[1]}
+PATCH=${SPLIT_LATEST_TAG[2]}
+
+PATCH=$((PATCH+1))
+
+NEW_TAG="v$MAJOR.$MINOR.$PATCH"
+
+echo "Updating $LATEST_TAG to $NEW_TAG"
+
+# Get current hash and see if it already has a tag
+NEEDS_TAG=$(git describe --contains $GIT_COMMIT 2>/dev/null)
+if [ -z "$NEEDS_TAG" ]; then
+    GIT_EMAIL=$(git show -s --format='%ae' $GIT_COMMIT) && \
+    echo "Email used for the commit was ${GIT_EMAIL}" && \
+    git config credential.helper 'cache --timeout=120' && \
+    git config user.email "${GIT_EMAIL}" && \
+    git config user.name "Automated Release" && \
+    echo "git tag -a ${NEW_TAG} -m \"Release ${NEW_TAG}\"" && \
+    git tag -a "${NEW_TAG}" -m "Release ${NEW_TAG}" && \
+    echo "Tagged commit with $NEW_TAG" && \
+    echo "git push origin ${NEW_TAG}"
+    git push origin "${NEW_TAG}" && \
+    echo "New tag pushed to GitHub"
+else
+    echo "There already is a tag on this commit"
+fi


### PR DESCRIPTION
### What this does

This PR adds the release process for the SDK. This involves adding a new GitHub action, which runs only in the `main` branch. The action increments the patch tag version, pushes it to GitHub, and creates a release using `goreleaser`.

### Notes for the reviewer
This was tested locally and in this branch and I could see the tags and release being created. It uses GitHub tags by default to version the released binary:
![Screenshot 2021-09-08 at 17 19 59](https://user-images.githubusercontent.com/81559517/132562162-22544df3-41a4-47c1-a3ba-03f54f12741d.png)

To test it locally, a new tag was created manually (then a second one using the script -for sanity testing - but then deleted). Then `goreleaser release --rm-dist` was run locally to generate the release. The steps will be documented under https://github.com/snyk/snyk-iac-custom-rules/pull/12.

For now, `brew` (MacOS), `scoop` (Windows), and `npmfs` (see https://github.com/open-policy-agent/conftest/blob/master/.goreleaser.yml#L48) were left out as we don't want to release this publicly yet.

We have generated an initial tag `v0.0.1`, so that when this is merged into `main` it will result in tag `v.0.0.2` with a published release.

### More information

- [Jira ticket CC-1130](https://snyksec.atlassian.net/browse/CC-1130)
- [Link to documentation](https://www.notion.so/snyk/Release-process-2b7b25f9ae524805b5b5f3327835bb90)

