### PR TITLE
feat: extend test command with --run flag [CC-153]

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,11 @@ import (
 var RootCommand = NewRootCmd()
 
 func NewRootCmd() cobra.Command {
-	return cobra.Command{
+	rootCommand := cobra.Command{
 		Use:   "snyk-iac-custom-rules",
 		Short: "Snyk IaC Custom Rules",
 		Long:  "An SDK to write, debug, test, and bundle custom rules for Snyk IaC.",
 	}
+	rootCommand.CompletionOptions.DisableDefaultCmd = true
+	return rootCommand
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -52,5 +52,6 @@ func init() {
 	testCommand.Flags().VarP(&testParams.Explain, "explain", "", "enable query explanations")
 	testCommand.Flags().DurationVar(&testParams.Timeout, "timeout", 5*time.Second, "set test timeout")
 	testCommand.Flags().StringSliceVarP(&testParams.Ignore, "ignore", "", []string{".*", "scripts", "build"}, "set file and directory names to ignore during loading (e.g., '.*' excludes hidden files)")
+	testCommand.Flags().StringVarP(&testParams.RunRegex, "run", "r", "", "run only test cases matching the regular expression")
 	RootCommand.AddCommand(testCommand)
 }

--- a/internal/test.go
+++ b/internal/test.go
@@ -21,10 +21,11 @@ const (
 )
 
 type TestCommandParams struct {
-	Verbose bool
-	Explain util.EnumFlag
-	Timeout time.Duration
-	Ignore  []string
+	Verbose  bool
+	Explain  util.EnumFlag
+	Timeout  time.Duration
+	Ignore   []string
+	RunRegex string
 }
 
 func RunTest(args []string, params *TestCommandParams) error {
@@ -62,7 +63,7 @@ func RunTest(args []string, params *TestCommandParams) error {
 		SetRuntime(info).
 		SetModules(modules).
 		SetTimeout(params.Timeout).
-		Filter("").
+		Filter(params.RunRegex).
 		Target(compile.TargetRego)
 
 	reporter := tester.PrettyReporter{

--- a/spec/help_spec.sh
+++ b/spec/help_spec.sh
@@ -10,7 +10,6 @@ Usage:
 
 Available Commands:
   build       Build an OPA WASM bundle
-  completion  generate the autocompletion script for the specified shell
   help        Help about any command
   parse       Parse a fixture into JSON format
   template    Template a new rule

--- a/spec/test_spec.sh
+++ b/spec/test_spec.sh
@@ -7,3 +7,12 @@ Describe './snyk-iac-custom-rules test ./fixtures/custom-rules'
 PASS: 3/3'
    End
 End
+
+Describe './snyk-iac-custom-rules test ./fixtures/custom-rules --run test_CUSTOM_1'
+   It 'returns passing test status'
+      When call ./snyk-iac-custom-rules test ./fixtures/custom-rules --run test_CUSTOM_1
+      The status should be success
+      The output should include 'Executing Rego test cases...
+PASS: 1/1'
+   End
+End


### PR DESCRIPTION
### What this does

This PR extends the existing `test` command with a `--run` flag that takes a regex and is used to filter tests. This way, you can provide the name of a test to run a single test as part of the test suite.

### Notes for the reviewer
Added an e2e shellspec test but thankfully we are fully using the OPA library so any other unit tests are not necessary

The `rootCommand.CompletionOptions.DisableDefaultCmd = true` line is added to remove a `completion` command from the SDK, since we're not using it.

### More information

- [Jira ticket CC-1153](https://snyksec.atlassian.net/browse/CC-1153)
- [Link to documentation](https://www.notion.so/snyk/Custom-Rules-SDK-b4a4c08899324996bf77dc0a3875beff)

