### PR TITLE
fix: os compatibility for paths

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -22,7 +23,11 @@ The 'build' command packages OPA policy and data files into gzipped tarballs con
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Building OPA WASM bundle...")
 		if len(args) == 0 {
-			args = append(args, "./")
+			currentDirectory, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			args = append(args, currentDirectory)
 		}
 		err := internal.RunBuild(args, buildParams)
 		if err != nil {

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path"
 
 	"github.com/spf13/cobra"
 
@@ -16,13 +18,18 @@ var templateCommand = &cobra.Command{
 The 'template' command generates some templating code for writing new rules.
 `,
 	SilenceUsage: true,
-
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Templating rule...")
-		if len(args) == 0 {
-			args = append(args, "./")
+		currentDirectory, err := os.Getwd()
+		if err != nil {
+			return err
 		}
-		err := internal.RunTemplate(args, templateParams)
+		if len(args) == 0 {
+			args = append(args, currentDirectory)
+		} else {
+			args = []string{path.Join(currentDirectory, args[0])}
+		}
+		err = internal.RunTemplate(args, templateParams)
 		if err != nil {
 			return err
 		}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -33,7 +34,11 @@ The 'test' command executes all test cases discovered in matching files. Test ca
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Executing Rego test cases...")
 		if len(args) == 0 {
-			args = append(args, "./")
+			currentDirectory, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			args = append(args, currentDirectory)
 		}
 		return internal.RunTest(args, testParams)
 	},

--- a/internal/template.go
+++ b/internal/template.go
@@ -3,8 +3,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path"
 	"strings"
 
 	"github.com/snyk/snyk-iac-custom-rules/util"
@@ -15,17 +13,13 @@ type TemplateCommandParams struct {
 }
 
 func RunTemplate(args []string, params *TemplateCommandParams) error {
-	currentDirectory, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	workingDirectory := path.Join(currentDirectory, args[0])
+	workingDirectory := args[0]
 
 	templating := util.Templating{
 		RuleName: params.Rule,
 		Replace:  strings.ReplaceAll,
 	}
-	err = templateRule(workingDirectory, templating)
+	err := templateRule(workingDirectory, templating)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What this does

This PR makes sure that, regardless of OS, if a path is not provided then we default to the correct current directory.