### PR TITLE
fix: better error message for provided paths

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -20,6 +21,12 @@ var buildCommand = &cobra.Command{
 The 'build' command packages OPA policy and data files into gzipped tarballs containing policies and data written as WASM.
 `,
 	SilenceUsage: true,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			return errors.New("Too many paths provided")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Building OPA WASM bundle...")
 		if len(args) == 0 {

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -19,7 +19,10 @@ The 'parse' command takes the path to a fixture and returns the JSON format that
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return errors.New("expected a path to be provided via the command")
+			return errors.New("Expected a path to be provided via the command")
+		}
+		if len(args) > 1 {
+			return errors.New("Too many paths provided")
 		}
 		return nil
 	},

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -18,6 +19,12 @@ var templateCommand = &cobra.Command{
 The 'template' command generates some templating code for writing new rules.
 `,
 	SilenceUsage: true,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			return errors.New("Too many paths provided")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Templating rule...")
 		currentDirectory, err := os.Getwd()

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -23,6 +24,12 @@ var testCommand = &cobra.Command{
 The 'test' command executes all test cases discovered in matching files. Test cases are rules whose names have the prefix "test_".
 `,
 	SilenceUsage: true,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			return errors.New("Too many paths provided")
+		}
+		return nil
+	},
 	PreRunE: func(Cmd *cobra.Command, args []string) error {
 		// If an --explain flag was set, turn on verbose output
 		if testParams.Explain.IsSet() {


### PR DESCRIPTION
### What this does

This PR adds more useful error messages to the SDK commands. The `build`, `test`, and `template` commands can take an optional `<path>` argument, but only one. And the `parse` command requires a `<path>` argument.

