### PR TITLE
chore: update the name of the binary in the release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+project_name: snyk-iac-rules
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
### What this does

This PR updates the name of the binaries for the release.

### Notes for the reviewer

We have updated the name everywhere else but the GoReleaser uses the repo name as the default project name, which is then used to name the release.

https://goreleaser.com/customization/project/

