### PR TITLE
fix: add missing capabilities to build

### DIFF
--- a/internal/build.go
+++ b/internal/build.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/compile"
 	"github.com/snyk/snyk-iac-custom-rules/util"
 )
@@ -29,8 +30,10 @@ func RunBuild(args []string, params *BuildCommandParams) error {
 	buf := bytes.NewBuffer(nil)
 
 	compiler := compile.New().
+		WithCapabilities(ast.CapabilitiesForThisVersion()).
 		WithTarget(params.Target.String()).
 		WithAsBundle(false).
+		WithOptimizationLevel(0).
 		WithOutput(buf).
 		WithEntrypoints(params.Entrypoint.Strings()...).
 		WithPaths(args...).


### PR DESCRIPTION
### What this does

This adds some missing `build` command options.

### Notes for the reviewer

We didn't see any problems but to be extra safe I'm adding these missing options for the `build` command from https://github.com/open-policy-agent/opa/blob/e88ad165ba25dfb7839adfd02213e23ebbbae3bf/cmd/build.go#L267.

I'm not including the bundle verification and signing because we don't support that anyway. The capabilities seems important and I'm surprised the rules work without them. Maybe there are some custom builtins that we're not using and so don't expose this issue.
