### PR TITLE
feat: use fixture paths in tests [CC-1184]

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -13,6 +13,7 @@ import (
 
 var TestIgnore = []string{
 	".*",
+	"fixtures",
 }
 
 var testCommand = &cobra.Command{
@@ -74,7 +75,7 @@ func init() {
 	testCommand.Flags().BoolVarP(&testParams.Verbose, "verbose", "v", false, "set verbose logging mode")
 	testCommand.Flags().VarP(&testParams.Explain, "explain", "", "enable query explanations")
 	testCommand.Flags().DurationVar(&testParams.Timeout, "timeout", 5*time.Second, "set test timeout")
-	testCommand.Flags().StringSliceVarP(&testParams.Ignore, "ignore", "", []string{".*"}, "set file and directory names to ignore during loading (e.g., '.*' excludes hidden files)")
+	testCommand.Flags().StringSliceVarP(&testParams.Ignore, "ignore", "", TestIgnore, "set file and directory names to ignore during loading (e.g., '.*' excludes hidden files)")
 	testCommand.Flags().StringVarP(&testParams.RunRegex, "run", "r", "", "run only test cases matching the regular expression")
 	RootCommand.AddCommand(testCommand)
 }

--- a/fixtures/custom-rules/rules/CUSTOM-1/main_test.rego
+++ b/fixtures/custom-rules/rules/CUSTOM-1/main_test.rego
@@ -6,18 +6,8 @@ import data.lib.testing
 test_CUSTOM_1 {
 	test_cases := [{
 		"want_msgs": ["input.resource.aws_security_group[denied].tags"],
-		"fixture": {"resource": {"aws_security_group": {"denied": {
-			"description": "Allow SSH inbound from anywhere",
-			"ingress": {
-				"cidr_blocks": ["0.0.0.0/0"],
-				"from_port": 22,
-				"protocol": "tcp",
-				"to_port": 22,
-			},
-			"name": "allow_ssh",
-			"vpc_id": "${aws_vpc.main.id}",
-		}}}},
+		"fixture": "test.tf",
 	}]
 
-	testing.evaluate_test_cases("CUSTOM-1", test_cases)
+	testing.evaluate_test_cases("CUSTOM-1", "./fixtures/custom-rules/rules/CUSTOM-1/fixtures", test_cases)
 }

--- a/fixtures/custom-rules/rules/CUSTOM-2/main_test.rego
+++ b/fixtures/custom-rules/rules/CUSTOM-2/main_test.rego
@@ -6,17 +6,8 @@ import data.lib.testing
 test_CUSTOM_2 {
 	test_cases := [{
 		"want_msgs": ["resource.aws_ami[denied].ebs_block_device[0]"],
-		"fixture": {"resource": {"aws_ami": {"denied": {
-			"ebs_block_device": {
-				"device_name": "/dev/xvda",
-				"encrypted": false,
-				"volume_size": 8,
-			},
-			"name": "aws_ami_not_encrypted",
-			"root_device_name": "/dev/xvda",
-			"virtualization_type": "hvm",
-		}}}},
+		"fixture": "test.tf",
 	}]
 
-	testing.evaluate_test_cases("CUSTOM-2", test_cases)
+	testing.evaluate_test_cases("CUSTOM-2", "./fixtures/custom-rules/rules/CUSTOM-2/fixtures", test_cases)
 }

--- a/fixtures/custom-rules/rules/CUSTOM-3/main_test.rego
+++ b/fixtures/custom-rules/rules/CUSTOM-3/main_test.rego
@@ -6,30 +6,8 @@ import data.lib.testing
 test_CUSTOM_3 {
 	test_cases := [{
 		"want_msgs": ["spec.externalIPs"],
-		"fixture": {
-			"apiVersion": "v1",
-			"kind": "Service",
-			"metadata": {
-				"name": "using-external-ip-default"
-			},
-			"spec": {
-				"externalIPs": [
-					"1.1.1.1"
-				],
-				"ports": [
-					{
-						"name": "http",
-						"port": 80,
-						"protocol": "TCP",
-						"targetPort": 8080
-					}
-				],
-				"selector": {
-					"app": "MyApp"
-				}
-			}
-		},
+		"fixture": "test.yaml",
 	}]
 
-	testing.evaluate_test_cases("CUSTOM-3", test_cases)
+	testing.evaluate_test_cases("CUSTOM-3", "./fixtures/custom-rules/rules/CUSTOM-3/fixtures", test_cases)
 }

--- a/internal/template.go
+++ b/internal/template.go
@@ -34,6 +34,7 @@ func RunTemplate(args []string, params *TemplateCommandParams) error {
 func templateRule(workingDirectory string, templating util.Templating) error {
 	var rulesDir string
 	var ruleDir string
+	var ruleFixtureDir string
 	var err error
 
 	err = startProgress("Template rules directory", func() error {
@@ -70,6 +71,28 @@ func templateRule(workingDirectory string, templating util.Templating) error {
 
 	err = startProgress(fmt.Sprintf("Template rules/%s/main_test.rego file", templating.RuleName), func() error {
 		return templateFile(ruleDir, "main_test.rego", "templates/main_test.tpl.rego", templating)
+	})
+	if err != nil {
+		return err
+	}
+
+	err = startProgress(fmt.Sprintf("Template rules/%s/fixtures directory", templating.RuleName), func() error {
+		ruleFixtureDir, err = createDirectory(ruleDir, "fixtures", true)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = startProgress(fmt.Sprintf("Template rules/%s/fixtures/allowed.json file", templating.RuleName), func() error {
+		return templateFile(ruleFixtureDir, "allowed.json", "templates/fixtures/allowed.json", templating)
+	})
+	if err != nil {
+		return err
+	}
+
+	err = startProgress(fmt.Sprintf("Template rules/%s/fixtures/denied.json file", templating.RuleName), func() error {
+		return templateFile(ruleFixtureDir, "denied.json", "templates/fixtures/denied.json", templating)
 	})
 	if err != nil {
 		return err

--- a/internal/template_test.go
+++ b/internal/template_test.go
@@ -28,6 +28,10 @@ var directories = []struct {
 		name:             "Test Rule",
 	},
 	{
+		workingDirectory: "./test/rules/Test Rule",
+		name:             "fixtures",
+	},
+	{
 		workingDirectory: "./test",
 		name:             "lib",
 	},
@@ -51,6 +55,16 @@ var files = []struct {
 		workingDirectory: "./test/rules/Test Rule",
 		name:             "main_test.rego",
 		template:         "templates/main_test.tpl.rego",
+	},
+	{
+		workingDirectory: "./test/rules/Test Rule/fixtures",
+		name:             "allowed.json",
+		template:         "templates/fixtures/allowed.json",
+	},
+	{
+		workingDirectory: "./test/rules/Test Rule/fixtures",
+		name:             "denied.json",
+		template:         "templates/fixtures/denied.json",
 	},
 	{
 		workingDirectory: "./test/lib",

--- a/spec/contract/snyk_spec.sh
+++ b/spec/contract/snyk_spec.sh
@@ -10,10 +10,14 @@ Describe 'Contract test'
             mkdir tmp
             
             # create a basic rule
-            ./snyk-iac-rules template ./tmp --rule Contract 
+            ./snyk-iac-rules template ./tmp --rule Contract
+            rm ./tmp/rules/Contract/fixtures/denied.json
+            rm ./tmp/rules/Contract/fixtures/allowed.json
 
             # write rule and test
             cp -r ./fixtures/custom-rules/rules/CUSTOM-3/* ./tmp/rules/Contract
+            # replace the fixture path so it's correct
+            sed -i '' -e 's#/fixtures/custom-rules/rules/CUSTOM-3/fixtures#/tmp/rules/Contract/fixtures#' ./tmp/rules/Contract/main_test.rego
 
             # run tests and make sure they pass
             ./snyk-iac-rules test ./tmp 

--- a/spec/e2e/template_spec.sh
+++ b/spec/e2e/template_spec.sh
@@ -11,6 +11,9 @@ Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test'
       The stderr should include 'Template rules/test directory'
       The stderr should include 'Template rules/test/main.rego file'
       The stderr should include 'Template rules/test/main_test.rego file'
+      The stderr should include 'Template rules/test/fixtures directory'
+      The stderr should include 'Template rules/test/fixtures/allowed.json file'
+      The stderr should include 'Template rules/test/fixtures/denied.json file'
       The output should include 'Generated template'
    End
 End

--- a/util/templates/fixtures/allowed.json
+++ b/util/templates/fixtures/allowed.json
@@ -1,0 +1,7 @@
+{
+    "spec": {
+        "template": {
+            "todo": false
+        }
+    }
+}

--- a/util/templates/fixtures/denied.json
+++ b/util/templates/fixtures/denied.json
@@ -1,0 +1,7 @@
+{
+    "spec": {
+        "template": {
+            "todo": true
+        }
+    }
+}

--- a/util/templates/main_test.tpl.rego
+++ b/util/templates/main_test.tpl.rego
@@ -6,23 +6,11 @@ import data.lib.testing
 test_{{ call .Replace .RuleName "-" "_" }} {
 	test_cases := [{
 		"want_msgs": [],
-		"fixture": {
-			"spec": {
-				"template": {
-					"todo": false
-				}
-			}
-		},
+		"fixture": "allowed.json",
 	}, {
 		"want_msgs": ["spec.template.todo"],
-		"fixture": {
-			"spec": {
-				"template": {
-					"todo": true
-				}
-			}
-		},
+		"fixture": "denied.json",
 	}]
 
-	testing.evaluate_test_cases("{{.RuleName}}", test_cases)
+	testing.evaluate_test_cases("{{.RuleName}}", "rules/{{.RuleName}}/fixtures", test_cases)
 }


### PR DESCRIPTION
### What this does

This PR is the result of feedback from usability testing. It updates the templating and utility Rego so that tests can be written by providing local fixture files. This is following the example in `cloud-config-opa-policies`.

### Notes for the reviewer

- The code for `util/templates/lib/testing/main.tpl.rego` was taken from https://github.com/snyk/cloud-config-opa-policies/blob/master/lib/testing/main.rego.
- Have modified the fixture files to match the new testing standard
- Test is covered by E2E, contract, and unit tests

<img width="1535" alt="Screenshot 2021-09-22 at 17 23 33" src="https://user-images.githubusercontent.com/81559517/134362036-16c27a21-74fa-482b-8750-a626cb43c06b.png">


### More information

- [Jira ticket CC-1184](https://snyksec.atlassian.net/browse/CC-1184)

