### PR TITLE
chore: homebrew, scoop, nfpms releases [CFG-327]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: write
+
 jobs:
   release:
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,7 +79,7 @@ brews:
 
     homepage: "https://snyk.io/"
     license: Apache-2.0
-    description: "Write, debug, test, and bundle custom rules for Snyk IaC."
+    description: "Write, debug, test, and bundle custom rules for Snyk Infrastructure as Code."
 
 scoop:
   # If set to auto, the release will not be uploaded to the scoop bucket
@@ -94,16 +94,16 @@ scoop:
 
   homepage: "https://snyk.io/"
   license: Apache-2.0
-  description: "Write, debug, test, and bundle custom rules for Snyk IaC."
+  description: "Write, debug, test, and bundle custom rules for Snyk Infrastructure as Code."
 
 # Publishes the deb and rpm files to the GitHub releases page.
 nfpms:
   - bindir: /usr/bin
-    description: "Write, debug, test, and bundle custom rules for Snyk IaC."
+    description: "Write, debug, test, and bundle custom rules for Snyk Infrastructure as Code."
     formats:
       - deb
       - rpm
-    homepage: https://github.com/snyk/snyk-iac-custom-rules
+    homepage: https://github.com/snyk/snyk-iac-rules
     license: Apache-2.0
 
 announce:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,21 +71,40 @@ brews:
     # If set to auto, the release will not be uploaded to the homebrew tap
     # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
     # Default is false.
-    skip_upload: true
+    skip_upload: false
+    # GitHub repository to push the formula to
+    tap:
+      owner: snyk
+      name: homebrew-tap
+
+    homepage: "https://snyk.io/"
+    license: Apache-2.0
+    description: "Write, debug, test, and bundle custom rules for Snyk IaC."
 
 scoop:
   # If set to auto, the release will not be uploaded to the scoop bucket
   # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
   # Default is false.
-  skip_upload: true
+  skip_upload: false
 
-dockers:
-  -
-    # If set to auto, the release will not be pushed to the Docker repository
-    #  in case there is an indicator of a prerelease in the tag, e.g. v1.0.0-rc1.
-    #
-    # Defaults to false.
-    skip_push: false
+  # Repository to push the app manifest to.
+  bucket:
+    owner: snyk
+    name: scoop-snyk
+
+  homepage: "https://snyk.io/"
+  license: Apache-2.0
+  description: "Write, debug, test, and bundle custom rules for Snyk IaC."
+
+# Publishes the deb and rpm files to the GitHub releases page.
+nfpms:
+  - bindir: /usr/bin
+    description: "Write, debug, test, and bundle custom rules for Snyk IaC."
+    formats:
+      - deb
+      - rpm
+    homepage: https://github.com/snyk/snyk-iac-custom-rules
+    license: Apache-2.0
 
 announce:
   twitter:


### PR DESCRIPTION
### What this does

This PR adds the Homebrew, Scoop, and NFPMS release

### Notes for the reviewer

The configuration is based off of: https://goreleaser.com/customization/scoop/ and https://goreleaser.com/customization/homebrew/.

The tap for homebrew is https://github.com/snyk/homebrew-tap
The bucket for scoop is https://github.com/snyk/scoop-snyk
Since these are owned by Hammer, we need to await their approval from https://snyk.slack.com/archives/C0127HWU0E7/p1632404109085600.

### More information

- [Jira ticket CFG-327](https://snyksec.atlassian.net/browse/CFG-327)
- [Link to documentation](https://www.notion.so/snyk/Release-process-2b7b25f9ae524805b5b5f3327835bb90#eb3ec89833d542bfbc53c0380085944f)

