### PR TITLE
Update RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ Once this PR is merged, the `Release SDK` GitHub action will generate a new GitH
 ## CI/CD
 As part of every PR from a feature branch to the `develop` branch, we run both CircleCI as well as the `E2E Tests` and `Contract Tests` GitHub Actions, which run our shellspec tests in Windows, Linux, and MacOS. The CircleCI pipeline runs the `golangci-lint` linter, `gofmt`, and `go mod tidy`, and then it runs `shellspec` end-to-end tests and the Golang unit tests on a Linux distribution.
 
-Once the PR is merged into `develop`, the `E2E Tests` and `Contract Tests` GitHub Actions run again. These actions also run in PRs opened from `develop` to `main`.
+Once the PR is merged into `develop`, the `E2E Tests` and `Contract Tests` GitHub Actions run again. These actions also run in PRs opened from `develop` to `main`. [Open Production Release PR](https://github.com/snyk/snyk-iac-rules/compare/main...develop?expand=1)
 
 Once the PR for the `main` branch has been merged, the `Release SDK` GitHub action runs, which increments the GitHub tag and creates a new GitHub release of the SDK.
 


### PR DESCRIPTION
### What this does

Adds a link to trigger a Production Release.

Note: We might deprecate the develop branch in the future.