### PR TITLE
chore: Update workflow to publish npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: ./scripts/release-npm.sh "${{ env.NEW_TAG }}"
       - run: npm publish
+        working-directory: dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
NPM Publish failed because we didn't switch directory before trying the run step. We need to cd into the dist/ directory first and then call the npm publish, else GH won't find the package.json file. 

Example of failure: https://github.com/snyk/snyk-iac-rules/runs/3767725322?check_suite_focus=true
Structure:
```
.
├── dist
│   ├── package.json
│   ├── snyk-iac-rules
│   ├── snyk-iac-rules-darwin-amd64
│   ├── snyk-iac-rules-darwin-arm64
│   ├── snyk-iac-rules-linux-amd64
│   ├── snyk-iac-rules-linux-arm64
│   └── snyk-iac-rules.exe
├── packaging
│   └── npm
│       ├── package.json.in
│       └── passthrough.js
├── scripts
│   ├── install-shellspec-win.sh
│   ├── release-github.sh
│   ├── release-npm.sh
│   ├── run-contract-win.sh
│   └── run-e2e-win.sh
├── snyk-iac-rules


37 directories, 86 files

```
