### PR TITLE
chore: Update package.json with correct github url

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ For the release process we use [GoReleaser](https://goreleaser.com/), which can 
 
 Click the [create a pull request][develop-release-pr] link to open a PR from `develop` to `main`
 
-[develop-release-pr]: https://github.com/snyk/snyk-iac-custom-rules/compare/main...develop?expand=1&title=Release%20develop%20to%20production&body=Release%20stable%20to%20production
+[develop-release-pr]: https://github.com/snyk/snyk-iac-rules/compare/main...develop?expand=1&title=Release%20develop%20to%20production&body=Release%20stable%20to%20production
 
 There are two release processes:
 1. Release of Golang binaries via GitHub Releases

--- a/packaging/npm/package.json.in
+++ b/packaging/npm/package.json.in
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/snyk/snyk-iac-custom-rules.git"
+    "url": "git+https://github.com/snyk/snyk-iac-rules.git"
   },
   "license": "Proprietary",
   "dependencies": {},


### PR DESCRIPTION
### What this does

Renames the github repo url for the generation of the package json. NPM registry should point to the correct repo url: https://www.npmjs.com/package/snyk-iac-rules

