### PR TITLE
fix: return error code on rego test failures

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -39,7 +39,8 @@ package, which takes the name of a rule as a first argument and an array of test
 See our documentation to learn more: 
 https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/testing-a-rule
 `,
-	SilenceUsage: true,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 1 {
 			return errors.New("Too many paths provided")


### PR DESCRIPTION
### What this does
Status code of rego failure is requried by CI systems
to determine that tasts are actually failing

### Notes for the reviewer

We have been caught by this when our CI was not failing but we had invalid rego code

Running locally the TestStartProgress  test was failing. Not sure what this does could use some advice on how to fix it

Example output
```
data.schemas.terraform.gcp.test_SNYK_CC_TF_87: PASS (78.529873ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_88: PASS (57.202348ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_89: PASS (57.03192ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_90: PASS (193.066311ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_91: PASS (12.058591ms)
data.schemas.terraform.test_deny: PASS (129.319905ms)
--------------------------------------------------------------------------------
PASS: 586/600
FAIL: 14/600
Error: exitCode: 2
exitCode: 2
```


We can pass empty error object which produces following output
```
data.schemas.terraform.gcp.test_SNYK_CC_TF_87: PASS (78.529873ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_88: PASS (57.202348ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_89: PASS (57.03192ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_90: PASS (193.066311ms)
data.schemas.terraform.gcp.test_SNYK_CC_TF_91: PASS (12.058591ms)
data.schemas.terraform.test_deny: PASS (129.319905ms)
--------------------------------------------------------------------------------
PASS: 586/600
FAIL: 14/600

```


### More information


