### PR TITLE
fix: template options in --help output

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -97,8 +97,8 @@ var templateParams = newTemplateCommandParams()
 
 func init() {
 	templateCommand.Flags().StringVarP(&templateParams.RuleID, "rule", "r", "", "provide rule id")
-	templateCommand.Flags().StringVarP(&templateParams.RuleTitle, "title", "s", "Default title", "provide rule title")
-	templateCommand.Flags().VarP(&templateParams.RuleSeverity, "severity", "t", "provide rule severity")
+	templateCommand.Flags().StringVarP(&templateParams.RuleTitle, "title", "t", "Default title", "provide rule title")
+	templateCommand.Flags().VarP(&templateParams.RuleSeverity, "severity", "s", "provide rule severity")
 	templateCommand.MarkFlagRequired("rule") //nolint
 	RootCommand.AddCommand(templateCommand)
 }

--- a/spec/e2e/build_spec.sh
+++ b/spec/e2e/build_spec.sh
@@ -3,6 +3,22 @@
 cleanup() { rm bundle.tar.gz; }
 AfterAll 'cleanup'
 
+Describe './snyk-iac-rules build --help'
+   It 'returns passing test status'
+      When call ./snyk-iac-rules build --help
+      The status should be success
+      The output should include 'Usage:
+  snyk-iac-rules build [path] [flags]
+
+Flags:
+  -e, --entrypoint string    set slash separated entrypoint path (default "rules/deny")
+  -h, --help                 help for build
+      --ignore strings       set file and directory names to ignore during loading (default [.*,fixtures,testing,*_test.rego])
+  -o, --output string        set the output filename (default "bundle.tar.gz")
+  -t, --target {rego,wasm}   set the output bundle target type (default wasm)'
+   End
+End
+
 Describe './snyk-iac-rules build ./fixtures/custom-rules --ignore testing --ignore "*_test.rego"'
    It 'returns passing test status'
       When call ./snyk-iac-rules build ./fixtures/custom-rules --ignore testing --ignore "*_test.rego"

--- a/spec/e2e/help_spec.sh
+++ b/spec/e2e/help_spec.sh
@@ -3,29 +3,7 @@ Describe './snyk-iac-rules'
   It 'returns help info'
     When call ./snyk-iac-rules
     The status should be success
-    The output should include 'SDK to write, debug, test, and bundle custom rules for Snyk Infrastructure as Code.
-
-Not sure where to start?
-
-1. Run the following command to learn how to generate a scaffolded rule:
-$ snyk-iac-rules template --help
-
-2. Run the following command to learn how to parse a file into the JSON structure that Rego understands:
-$ snyk-iac-rules parse --help
-
-3. Run the following command to learn how to test a Rego rule:
-$ snyk-iac-rules test --help
-
-4. Run the following command to learn how to build the bundle for the Snyk IaC CLI:
-$ snyk-iac-rules build --help
-
-5. Run the following command to learn how to push the bundle to a Container Registry:
-$ snyk-iac-rules push --help
-
-See our documentation to learn more:
-https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules
-
-Usage:
+    The output should include 'Usage:
   snyk-iac-rules [command]
 
 Available Commands:

--- a/spec/e2e/parse_spec.sh
+++ b/spec/e2e/parse_spec.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+
+Describe './snyk-iac-rules parse --help'
+   It 'returns passing test status'
+      When call ./snyk-iac-rules parse --help
+      The status should be success
+      The output should include 'Usage:
+  snyk-iac-rules parse <path> [flags]
+
+Flags:
+  -f, --format {hcl2,yaml}   choose the format for the parser (default hcl2)
+  -h, --help                 help for parse'
+	End
+End
+
 Describe './snyk-iac-rules parse ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/test.tf'
    It 'returns passing test status'
       When call ./snyk-iac-rules parse ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/test.tf

--- a/spec/e2e/push_spec.sh
+++ b/spec/e2e/push_spec.sh
@@ -8,6 +8,19 @@ cleanup() { rm bundle.tar.gz; }
 BeforeEach 'setup'
 AfterEach 'cleanup'
 
+Describe './snyk-iac-rules push --help'
+   It 'returns passing test status'
+      When call ./snyk-iac-rules push --help
+      The status should be success
+      The output should include 'Usage:
+  snyk-iac-rules push <path> [flags]
+
+Flags:
+  -h, --help              help for push
+  -r, --registry string   provide container registry'
+   End
+End
+
 Describe './snyk-iac-rules push -r docker.io/test/test test.jpg'
    It 'returns failing test status'
       When call ./snyk-iac-rules push -r docker.io/test/test test.jpg

--- a/spec/e2e/template_spec.sh
+++ b/spec/e2e/template_spec.sh
@@ -3,6 +3,21 @@
 cleanup() { rm -rf ./fixtures/custom-rules/rules/test; }
 AfterAll 'cleanup'
 
+Describe './snyk-iac-rules template --help'
+   It 'returns passing test status'
+      When call ./snyk-iac-rules template --help
+      The status should be success
+      The output should include 'Usage:
+  snyk-iac-rules template [path] [flags]
+
+Flags:
+  -h, --help                                  help for template
+  -r, --rule string                           provide rule id
+  -s, --severity {low,medium,high,critical}   provide rule severity (default low)
+  -t, --title string                          provide rule title (default "Default title")'
+   End
+End
+
 Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test'
    It 'returns passing test status'
       When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test

--- a/spec/e2e/test_spec.sh
+++ b/spec/e2e/test_spec.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+
+Describe './snyk-iac-rules test --help'
+   It 'returns passing test status'
+      When call ./snyk-iac-rules test --help
+      The status should be success
+      The output should include 'Usage:
+  snyk-iac-rules test [path] [flags]
+
+Flags:
+      --explain {fails,full,notes}   enable query explanations (default fails)
+  -h, --help                         help for test
+      --ignore strings               set file and directory names to ignore during loading (default [.*,fixtures])
+  -r, --run string                   run only test cases matching the regular expression
+      --timeout duration             set test timeout (default 5s)
+  -v, --verbose                      set verbose logging mode'
+   End
+End
+
 Describe './snyk-iac-rules test ./fixtures/custom-rules'
    It 'returns passing test status'
       When call ./snyk-iac-rules test ./fixtures/custom-rules


### PR DESCRIPTION
### What this does

This PR fixes a small mistake in the `template` command where the shorthand options are mixed up. It also includes some shellspec testing to cover testing these options.

