### PR TITLE
fix: remove custom code for os-specific path

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -49,13 +48,9 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			currentDirectory, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			args = append(args, currentDirectory)
+			// add default path if not provided
+			args = append(args, ".")
 		}
-
 		err := internal.RunBuild(args, buildParams)
 		if err != nil {
 			return err

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -66,18 +64,11 @@ $ snyk-iac-rules test --help
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// prepare directory for templating
-		currentDirectory, err := os.Getwd()
-		if err != nil {
-			return err
-		}
 		if len(args) == 0 {
-			args = append(args, currentDirectory)
-		} else {
-			args = []string{path.Join(currentDirectory, args[0])}
+			// add default path if not provided
+			args = append(args, ".")
 		}
-
-		err = internal.RunTemplate(args, templateParams)
+		err := internal.RunTemplate(args, templateParams)
 		if err != nil {
 			return err
 		}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -57,11 +56,8 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			currentDirectory, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			args = append(args, currentDirectory)
+			// add default path if not provided
+			args = append(args, ".")
 		}
 		return internal.RunTest(args, testParams)
 	},

--- a/spec/contract/snyk_spec.sh
+++ b/spec/contract/snyk_spec.sh
@@ -3,85 +3,123 @@
 cleanupBundle() { rm bundle.tar.gz; }
 AfterAll 'cleanupBundle'
 
-cleanup() { rm -rf ./tmp; unset OCI_REGISTRY_URL; }
-AfterEach 'cleanup'
+cleanupTmp() { rm -rf ./tmp; }
+AfterEach 'cleanupTmp'
 
-Describe 'Contract test'
-    It 'verifies contract between the SDK and Snyk via flag'
-        snyk_iac_test() {
-            # create tmp test directory for contract tests
-            mkdir tmp
-            
-            # create a basic rule
-            ./snyk-iac-rules template ./tmp --rule Contract
+Describe 'Contract test between the SDK and the Snyk CLI'
+    Describe 'Via --rules flag'
+        It 'Verifies custom rule without a path'
+            snyk_iac_test() {
+                # create tmp test directory for contract tests
+                mkdir tmp
+                cd tmp
 
-            # replace the fixture path so it's correct
-            sed -i '' -e 's#/rules/Contract/fixtures#/tmp/rules/Contract/fixtures#' ./tmp/rules/Contract/main_test.rego
+                # create a basic rule
+                ../snyk-iac-rules template --rule Contract
 
-            # run tests and make sure they pass
-            ./snyk-iac-rules test ./tmp 
+                # run tests and make sure they pass
+                ../snyk-iac-rules test
 
-            # create bundle
-            ./snyk-iac-rules build ./tmp --ignore "testing" --ignore "*_test.rego" 
+                # create bundle
+                ../snyk-iac-rules build --ignore "testing" --ignore "*_test.rego" 
 
-            # authenticate with Snyk
-            snyk auth $SNYK_TOKEN 
+                # authenticate with Snyk
+                snyk auth $SNYK_TOKEN 
 
-            # use bundle with Snyk
-            snyk iac test --rules=./bundle.tar.gz ./tmp/rules/Contract/fixtures/denied.tf
-            echo $?
-        }
+                # use bundle with Snyk
+                snyk iac test --rules=./bundle.tar.gz ./rules/Contract/fixtures/denied.tf
+                echo $?
+            }
 
-        When call snyk_iac_test
-        The status should eq 0
-        The output should include "Generated template" # the rule was tempalted successfully
-        The output should include "PASS: 1/1" # the tests passed
-        The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
-        The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
-        The stderr should be present # from the templating
+            When call snyk_iac_test
+            The status should eq 0
+            The output should include "Generated template" # the rule was tempalted successfully
+            The output should include "PASS: 1/1" # the tests passed
+            The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
+            The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The stderr should be present # from the templating
+
+            cd ../
+        End
+
+        It 'Verifies custom rule with relative path'
+            snyk_iac_test() {
+                # create tmp test directory for contract tests
+                mkdir tmp
+
+                # create a basic rule
+                ./snyk-iac-rules template ./tmp --rule Contract
+
+                # replace the fixture path so it's correct
+                sed -i '' -e 's#/rules/Contract/fixtures#/tmp/rules/Contract/fixtures#' ./tmp/rules/Contract/main_test.rego
+
+                # run tests and make sure they pass
+                ./snyk-iac-rules test ./tmp 
+
+                # create bundle
+                ./snyk-iac-rules build ./tmp --ignore "testing" --ignore "*_test.rego" 
+
+                # authenticate with Snyk
+                snyk auth $SNYK_TOKEN 
+
+                # use bundle with Snyk
+                snyk iac test --rules=./bundle.tar.gz ./tmp/rules/Contract/fixtures/denied.tf
+                echo $?
+            }
+
+            When call snyk_iac_test
+            The status should eq 0
+            The output should include "Generated template" # the rule was tempalted successfully
+            The output should include "PASS: 1/1" # the tests passed
+            The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
+            The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The stderr should be present # from the templating
+        End
     End
 
-    It 'verifies contract between the SDK and Snyk via distribution'
+    Describe 'Via push and pull'
         skip_push_test() { ! [ -z "$SKIP_PUSH_TEST" ]; }
         Skip if 'skip environment variable is set' skip_push_test
-        snyk_iac_test() {
-            # create tmp test directory for contract tests
-            mkdir tmp
-            
-            # create a basic rule
-            ./snyk-iac-rules template ./tmp --rule Contract
+        It 'verifies contract between the SDK and Snyk via distribution'
+            snyk_iac_test() {
+                # create tmp test directory for contract tests
+                mkdir tmp
+                cd tmp
 
-            # replace the fixture path so it's correct
-            sed -i '' -e 's#/rules/Contract/fixtures#/tmp/rules/Contract/fixtures#' ./tmp/rules/Contract/main_test.rego
+                # create a basic rule
+                ../snyk-iac-rules template --rule Contract
 
-            # run tests and make sure they pass
-            ./snyk-iac-rules test ./tmp 
+                # run tests and make sure they pass
+                ../snyk-iac-rules test
 
-            # create bundle
-            ./snyk-iac-rules build ./tmp --ignore "testing" --ignore "*_test.rego" 
+                # create bundle
+                ../snyk-iac-rules build --ignore "testing" --ignore "*_test.rego" 
 
-            # push bundle
-            ./snyk-iac-rules push --registry $OCI_REGISTRY_NAME bundle.tar.gz
+                # push bundle
+                ../snyk-iac-rules push --registry $OCI_REGISTRY_NAME bundle.tar.gz
 
-            # authenticate with Snyk
-            snyk auth $SNYK_TOKEN 
+                # authenticate with Snyk
+                snyk auth $SNYK_TOKEN 
 
-            # set environment variables for the CLI
-            export OCI_REGISTRY_URL=https://registry-1.$OCI_REGISTRY_NAME
-            export OCI_REGISTRY_USERNAME=$OCI_REGISTRY_USERNAME
-            export OCI_REGISTRY_PASSWORD=$OCI_REGISTRY_PASSWORD
+                # set environment variables for the CLI
+                export OCI_REGISTRY_URL=https://registry-1.$OCI_REGISTRY_NAME
+                export OCI_REGISTRY_USERNAME=$OCI_REGISTRY_USERNAME
+                export OCI_REGISTRY_PASSWORD=$OCI_REGISTRY_PASSWORD
 
-            # use bundle with Snyk
-            snyk iac test ./tmp/rules/Contract/fixtures/denied.tf
-            echo $?
-        }
+                # use bundle with Snyk
+                snyk iac test ./rules/Contract/fixtures/denied.tf
+                echo $?
+            }
 
-        When call snyk_iac_test
-        The status should eq 0
-        The output should include "Generated template" # the rule was tempalted successfully
-        The output should include "PASS: 1/1" # the tests passed
-        The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
-        The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
-        The stderr should be present # from the templating
+            When call snyk_iac_test
+            The status should eq 0
+            The output should include "Generated template" # the rule was tempalted successfully
+            The output should include "PASS: 1/1" # the tests passed
+            The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
+            The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The stderr should be present # from the templating
+
+            cd ../
+        End
     End
 End


### PR DESCRIPTION
### What this does

This PR removes some extra logic we added in case `.` does not work in Windows. The contract and e2e tests run the SDK against Windows, Linux, and MacOS so I **think** they would complain if the `.` was a problem.
