### PR TITLE
test: contract test supported registries via shellspec

### DIFF
--- a/.github/actions/setup_shellspec/action.yml
+++ b/.github/actions/setup_shellspec/action.yml
@@ -3,13 +3,12 @@ description: 'Sets up Shellspec testing by installing the Snyk CLI, Shellspec, a
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
-
     - uses: actions/setup-node@v1
       with:
         node-version: 15
 
     - name: Install Snyk with npm
+      shell: bash
       run: |
         echo "node_version: ${{ matrix.node_version }}"
         node -v
@@ -21,9 +20,11 @@ runs:
         go-version: '1.17'
 
     - name: Build custom rules SDK
+      shell: bash
       run: go build -o snyk-iac-rules .
 
     - name: Install shellspec
+      shell: bash
       run: |
         curl -fsSL https://git.io/shellspec | sh -s -- -y
         sudo ln -s ${HOME}/.local/lib/shellspec/shellspec /usr/local/bin/shellspec

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -7,7 +7,7 @@ on:
       - '!main'     # excludes main
 
 jobs:
-  smoke_test:
+  contract_test:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,6 @@ jobs:
           shellspec "spec/e2e"
         env:
           SKIP_PUSH_TEST: true # Docker is not supported in MacOS: https://github.com/docker/login-action/issues/14
-          OCI_REGISTRY_NAME: ${{ secrets.OCI_REGISTRY_NAME }}
 
       - name: Run shellspec tests - Windows
         if: ${{ matrix.os == 'windows' }}

--- a/.github/workflows/registries.yml
+++ b/.github/workflows/registries.yml
@@ -1,0 +1,67 @@
+name: Registries Tests
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  dockerhub:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup
+        uses: ./.github/actions/setup_shellspec # use local action
+        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        if: ${{ matrix.os != 'macos' }}
+        with:
+          username: ${{ secrets.OCI_DOCKERHUB_REGISTRY_USERNAME }}
+          password: ${{ secrets.OCI_DOCKERHUB_REGISTRY_PASSWORD }}
+
+      - name: Run shellspec tests
+        working-directory: ./
+        shell: bash -l {0} # run bash with --login flag to load .bash_profile that's used by yarn install method
+        run: |
+          export PATH="/usr/local/bin/snyk-mac/docker:$PATH"
+
+          shellspec "spec/registries"
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          OCI_DOCKERHUB_REGISTRY_NAME: ${{ secrets.OCI_DOCKERHUB_REGISTRY_NAME }}
+          OCI_DOCKERHUB_REGISTRY_URL: ${{ secrets.OCI_DOCKERHUB_REGISTRY_URL }}
+          OCI_DOCKERHUB_REGISTRY_USERNAME: ${{ secrets.OCI_DOCKERHUB_REGISTRY_USERNAME }}
+          OCI_DOCKERHUB_REGISTRY_PASSWORD: ${{ secrets.OCI_DOCKERHUB_REGISTRY_PASSWORD }}
+
+  azure:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup
+        uses: ./.github/actions/setup_shellspec # use local action
+
+      - name: Login to Azure
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.OCI_AZURE_REGISTRY }}
+          username: ${{ secrets.OCI_AZURE_REGISTRY_USERNAME }}
+          password: ${{ secrets.OCI_AZURE_REGISTRY_PASSWORD }}
+
+      - name: Run shellspec tests
+        working-directory: ./
+        shell: bash -l {0} # run bash with --login flag to load .bash_profile that's used by yarn install method
+        run: |
+          export PATH="/usr/local/bin/snyk-mac/docker:$PATH"
+
+          shellspec "spec/registries"
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          OCI_AZURE_REGISTRY_NAME: ${{ secrets.OCI_AZURE_REGISTRY_NAME }}
+          OCI_AZURE_REGISTRY_URL: ${{ secrets.OCI_AZURE_REGISTRY_URL }}
+          OCI_AZURE_REGISTRY_USERNAME: ${{ secrets.OCI_AZURE_REGISTRY_USERNAME }}
+          OCI_AZURE_REGISTRY_PASSWORD: ${{ secrets.OCI_AZURE_REGISTRY_PASSWORD }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,6 +121,9 @@ $ ./snyk-iac-rules {command}
 
 Make sure to build the Golang binary first by following the instructions in the README.
 
+#### End-to-end tests
+**Note** These instructions are for internal use only, as the  feature is behind a feature flag and entitlement.
+
 To run `shellspec` tests, set the following environment variables based on the registry you want to push your bundle to:
 ```
 export OS=<your OS>
@@ -131,11 +134,44 @@ export OCI_REGISTRY_PASSWORD=<password>
 
 From the project's root folder, run `shellspec "spec/e2e"` to run [shellspec](https://github.com/shellspec/shellspec) tests for the end-to-end flow. This will verify the behaviour of the commands against the fixtures in the `./fixtures` folder and make sure the output and exit codes are correct.
 
-To run the contract tests with Snyk, install Snyk by running `npm i -g snyk` and set the `SNYK_TOKEN` to the Auth Token from https://app.snyk.io/account. Finally, run `shellspec "spec/contract"` to verify if the generated bundle from the SDK is valid for the Snyk CLI(make sure the custom rules feature flag is enabled: `iacCustomRules`).
+These tests run as part of the entire CI/CD for our three supported OS's (Linux, MacOs, and Windows), apart from when we release a new version of the SDK.
+
+#### Contract tests with the Snyk CLI
+**Note** These instructions are for internal use only, as the  feature is behind a feature flag and entitlement.
+
+To run the contract tests with Snyk, install Snyk by running `npm i -g snyk` and set the `SNYK_TOKEN` to the Auth Token from https://app.snyk.io/account. 
+
+Finally, run `shellspec "spec/contract"` to verify if the generated bundle from the SDK is valid for the Snyk CLI. 
+
+These tests run as part of the entire CI/CD for our three supported OS's (Linux, MacOs, and Windows), apart from when we release a new version of the SDK.
+
+#### End-to-End tests for Supported Registries
+**Note** These instructions are for internal use only, as the  feature is behind a feature flag and entitlement.
+
+To run the tests for supported registries, follow the same steps as the contract tests but also set the following environment variables and log into the registries manually:
+```
+export OCI_DOCKERHUB_REGISTRY_URL=
+export OCI_DOCKERHUB_REGISTRY_NAME=
+export OCI_DOCKERHUB_REGISTRY_USERNAME=
+export OCI_DOCKERHUB_REGISTRY_PASSWORD=
+
+export OCI_AZURE_REGISTRY_URL=
+export OCI_AZURE_REGISTRY_NAME=
+export OCI_AZURE_REGISTRY_USERNAME=
+export OCI_AZURE_REGISTRY_PASSWORD=
+```
+
+Finally, run `shellspec "spec/registries"` to verify if the generated bundle from the SDK is valid for the Snyk CLI.
+
+These tests run as part of the CI/CD for the `develop` branch on Linux only.
+
+#### Unit tests
 
 Alternatively, you can run `go test ./...` for Golang unit tests. These test the files under `./internal` and `./util` and make sure complex behaviour is maintained between code changes.
 
 For test coverage, run `go test -coverprofile cover.out fmt ./...` and then `go tool cover -html=cover.out` to see what is missing.
+
+These tests run as part of the entire CI/CD, apart from when we release a new version of the SDK.
 
 **Note**
 All the fixtures under the `./fixture` folder are used for all Shellspec tests.

--- a/spec/contract/snyk_spec.sh
+++ b/spec/contract/snyk_spec.sh
@@ -80,7 +80,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
     Describe 'Via push and pull'
         skip_push_test() { ! [ -z "$SKIP_PUSH_TEST" ]; }
         Skip if 'skip environment variable is set' skip_push_test
-        It 'verifies contract between the SDK and Snyk via distribution'
+        It 'verifies contract between the SDK and Snyk'
             snyk_iac_test() {
                 # create tmp test directory for contract tests
                 mkdir tmp
@@ -98,16 +98,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
                 # push bundle
                 ../snyk-iac-rules push --registry $OCI_REGISTRY_NAME-$OS bundle.tar.gz
 
-                # authenticate with Snyk
-                snyk auth $SNYK_TOKEN 
-
-                # set environment variables for the CLI
-                export OCI_REGISTRY_URL=https://registry-1.$OCI_REGISTRY_NAME-$OS
-                export OCI_REGISTRY_USERNAME=$OCI_REGISTRY_USERNAME
-                export OCI_REGISTRY_PASSWORD=$OCI_REGISTRY_PASSWORD
-
-                # use bundle with Snyk
-                snyk iac test ./rules/Contract/fixtures/denied.tf
+                @registry_test https://registry-1.$OCI_REGISTRY_NAME-$OS $OCI_REGISTRY_USERNAME $OCI_REGISTRY_PASSWORD ./rules/Contract/fixtures/denied.tf
                 echo $?
             }
 

--- a/spec/e2e/push_spec.sh
+++ b/spec/e2e/push_spec.sh
@@ -64,7 +64,7 @@ End
 Describe './snyk-iac-rules push -r $OCI_REGISTRY_NAME bundle.tar.gz'
    It 'returns passing test status'
       skip_push_test() { ! [ -z "$SKIP_PUSH_TEST" ]; }
-      Skip if 'skip environment variable is set' skip_push_test
+      Skip if 'environment variable is set' skip_push_test
       When call ./snyk-iac-rules push -r $OCI_REGISTRY_NAME bundle.tar.gz
       The status should be success
       The output should include 'bundle.tar.gz'

--- a/spec/registries/e2e_spec.sh
+++ b/spec/registries/e2e_spec.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+setup() {
+    # create bundle
+    ./snyk-iac-rules build ./fixtures/custom-rules --ignore "testing" --ignore "*_test.rego" 
+}
+
+cleanup() {
+    rm bundle.tar.gz;
+}
+
+BeforeAll 'setup'
+AfterAll 'cleanup'
+
+Describe 'Supported Registry'
+    registry_test() {
+        OCI_REGISTRY_NAME="$1"
+        OCI_REGISTRY_URL="$2"
+        OCI_REGISTRY_USERNAME="$3"
+        OCI_REGISTRY_PASSWORD="$4"
+        ./snyk-iac-rules push --registry "$OCI_REGISTRY_NAME" bundle.tar.gz
+
+        @registry_test "$OCI_REGISTRY_URL" "$OCI_REGISTRY_USERNAME" "$OCI_REGISTRY_PASSWORD" ./fixtures/custom-rules/rules/CUSTOM-1/fixtures/test.tf
+    }
+    Describe 'DockerHub'
+        Skip if 'environment variable is not set'  [ -z "$OCI_DOCKERHUB_REGISTRY_URL" ]
+        It "can push and pull"
+            When call registry_test "$OCI_DOCKERHUB_REGISTRY_NAME" "$OCI_DOCKERHUB_REGISTRY_URL" "$OCI_DOCKERHUB_REGISTRY_USERNAME" "$OCI_DOCKERHUB_REGISTRY_PASSWORD"
+            The status should eq 1
+            The output should include 'Missing tags [Low Severity] [CUSTOM-1]' # it should include the custom rule in its output
+            The stderr should be present # from the test limit
+        End
+    End
+
+    Describe "Azure"
+        Skip if 'environment variable is not set'  [ -z "$OCI_AZURE_REGISTRY_URL" ]
+        It "can push and pull"
+            When call registry_test "$OCI_AZURE_REGISTRY_NAME" "$OCI_AZURE_REGISTRY_URL" "$OCI_AZURE_REGISTRY_USERNAME" "$OCI_AZURE_REGISTRY_PASSWORD"
+            The status should eq 1
+            The output should include 'Missing tags [Low Severity] [CUSTOM-1]' # it should include the custom rule in its output
+            The stderr should be present # from the test limit
+        End
+    End
+
+End

--- a/spec/support/bin/@registry_test
+++ b/spec/support/bin/@registry_test
@@ -1,0 +1,18 @@
+# Script generated with shellspec --gen-bin
+# Runs the `snyk` command authenticated with Snyk and with the OCI Registry URLs set.
+# It expects the `SNYK_TOKEN` environment variable to be set to the authentication token
+# of the org.
+# Usage within Shellspec tests:
+#     % @registry_test <registry_url> <registry_username> <registry_password> <file_path>
+#!/bin/sh -e
+. "$SHELLSPEC_SUPPORT_BIN"
+# authenticate with Snyk
+snyk auth $SNYK_TOKEN 
+
+# set environment variables for the CLI
+export OCI_REGISTRY_URL=$1
+export OCI_REGISTRY_USERNAME=$2
+export OCI_REGISTRY_PASSWORD=$3
+
+# use bundle with Snyk
+snyk iac test $4


### PR DESCRIPTION
### What this does

This ticket introduces contract tests for supported registries, verifying the `push` and `pull` from the SDK all the way to the snyk CLI. This is required for testing our supported registries, which we will document publicly in our documentation. As we add more registries to these tests, we can update the documentation too.

### Notes for the reviewer

The documentation linked at the bottom of the description shows how to login and push the bundle, plus what credentials to use.

I've configured the tests to only run on `develop`, since we already test a full end-to-end flow and contract with DockerHub. The GitHub action ran successfully in a test run:
![Screenshot 2021-10-20 at 15 15 32](https://user-images.githubusercontent.com/81559517/138110790-6a69bfb4-ace4-44db-b845-183074714d9a.png)
![Screenshot 2021-10-20 at 15 15 40](https://user-images.githubusercontent.com/81559517/138110796-7f4b8fbc-e227-459f-8564-796b9b182024.png)

I've also moved the `action.yml` file once I realised I don't need to release it as an action and can use it locally (which also helped with testing).


### More information
- [Jira ticket CFG-1103](https://snyksec.atlassian.net/browse/CFG-1103)
- [Jira ticket CFG-1104](https://snyksec.atlassian.net/browse/CFG-1104)
- [Link to documentation](https://www.notion.so/snyk/Testing-4478655847fd49ec9ef103c63b8e0ecf)

