### PR TITLE
chore: add action to be used by registry testing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,35 @@
+name: 'Setup Shellspec testing'
+description: 'Sets up Shellspec testing by installing the Snyk CLI, Shellspec, and building the SDK.'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 15
+
+    - name: Install Snyk with npm
+      run: |
+        echo "node_version: ${{ matrix.node_version }}"
+        node -v
+        echo "install snyk with npm"
+        npm install -g snyk
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Build custom rules SDK
+      run: go build -o snyk-iac-rules .
+
+    - name: Install shellspec
+      run: |
+        curl -fsSL https://git.io/shellspec | sh -s -- -y
+        sudo ln -s ${HOME}/.local/lib/shellspec/shellspec /usr/local/bin/shellspec
+        ls -la ${HOME}/.local/lib/shellspec
+        echo "shellspec symlink:"
+        ls -la /usr/local/bin/shellspec
+        /usr/local/bin/shellspec --version
+        which shellspec
+        shellspec --version


### PR DESCRIPTION
### What this does

This PR adds an action that will be exposed by this repository to setup our environment for shellspec testing. It will be used by a future GitHub action to setup the environment for each of our supported registries. It is required so we don't introduce duplication in our GitHub actions. The supported registries will be tested using `shellspec`, which allows us to test the end-to-end flow from pushing a bundle to pulling it with the snyk CLI. 

This action was written based on:
- https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
- https://github.blog/changelog/2021-08-25-github-actions-reduce-duplication-with-action-composition/

It will be exposed from this repository and used as such:
```
      - name: Setup
        uses: actions/snyk-iac-rules@v1
```

I haven't been able to test it yet because it needs to be published. I will test it as part of https://github.com/snyk/snyk-iac-rules/pull/66.