### PR TITLE
feat: add capabilities option to build [CFG-1091]

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -63,8 +63,9 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 
 func newBuildCommandParams() *internal.BuildCommandParams {
 	return &internal.BuildCommandParams{
-		Entrypoint: util.NewRepeatedStringFlag("rules/deny"),
-		Target:     util.NewEnumFlag(internal.TargetWasm, []string{internal.TargetRego, internal.TargetWasm}),
+		Entrypoint:   util.NewRepeatedStringFlag("rules/deny"),
+		Target:       util.NewEnumFlag(internal.TargetWasm, []string{internal.TargetRego, internal.TargetWasm}),
+		Capabilities: util.NewCapabilitiesFlag(),
 	}
 }
 
@@ -75,5 +76,7 @@ func init() {
 	buildCommand.Flags().StringVarP(&buildParams.OutputFile, "output", "o", "bundle.tar.gz", "set the output filename")
 	buildCommand.Flags().StringSliceVarP(&buildParams.Ignore, "ignore", "", BuildIgnore, "set file and directory names to ignore during loading")
 	buildCommand.Flags().VarP(&buildParams.Target, "target", "t", "set the output bundle target type")
+	buildCommand.Flags().VarP(&buildParams.Capabilities, "capabilities", "c", "set configurable set of OPA capabilities")
+
 	RootCommand.AddCommand(buildCommand)
 }

--- a/internal/build.go
+++ b/internal/build.go
@@ -20,17 +20,27 @@ const (
 )
 
 type BuildCommandParams struct {
-	Entrypoint util.RepeatedStringFlag
-	OutputFile string
-	Ignore     []string
-	Target     util.EnumFlag
+	Entrypoint   util.RepeatedStringFlag
+	OutputFile   string
+	Ignore       []string
+	Target       util.EnumFlag
+	Capabilities util.CapabilitiesFlag
 }
 
 func RunBuild(args []string, params *BuildCommandParams) error {
 	buf := bytes.NewBuffer(nil)
 
+	var capabilities *ast.Capabilities
+	// if capabilities are not provided as a cmd flag,
+	// then ast.CapabilitiesForThisVersion must be called
+	// within dobuild to ensure custom builtins are properly captured
+	if params.Capabilities.C != nil {
+		capabilities = params.Capabilities.C
+	} else {
+		capabilities = ast.CapabilitiesForThisVersion()
+	}
 	compiler := compile.New().
-		WithCapabilities(ast.CapabilitiesForThisVersion()).
+		WithCapabilities(capabilities).
 		WithTarget(params.Target.String()).
 		WithAsBundle(false).
 		WithOptimizationLevel(0).

--- a/spec/e2e/build_spec.sh
+++ b/spec/e2e/build_spec.sh
@@ -11,11 +11,12 @@ Describe './snyk-iac-rules build --help'
   snyk-iac-rules build [path] [flags]
 
 Flags:
-  -e, --entrypoint string    set slash separated entrypoint path (default "rules/deny")
-  -h, --help                 help for build
-      --ignore strings       set file and directory names to ignore during loading (default [.*,fixtures,testing,*_test.rego])
-  -o, --output string        set the output filename (default "bundle.tar.gz")
-  -t, --target {rego,wasm}   set the output bundle target type (default wasm)'
+  -c, --capabilities string   set configurable set of OPA capabilities
+  -e, --entrypoint string     set slash separated entrypoint path (default "rules/deny")
+  -h, --help                  help for build
+      --ignore strings        set file and directory names to ignore during loading (default [.*,fixtures,testing,*_test.rego])
+  -o, --output string         set the output filename (default "bundle.tar.gz")
+  -t, --target {rego,wasm}    set the output bundle target type (default wasm)'
    End
 End
 

--- a/util/capabilities_flag.go
+++ b/util/capabilities_flag.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"os"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// CapabilitiesFlag was taken from https://github.com/open-policy-agent/opa/blob/v0.31.0/cmd/flags.go#L160
+
+type CapabilitiesFlag struct {
+	C    *ast.Capabilities
+	path string
+}
+
+func NewCapabilitiesFlag() CapabilitiesFlag {
+	return CapabilitiesFlag{
+		// cannot call ast.CapabilitiesForThisVersion here because
+		// custom builtins cannot be registered by this point in execution
+		C: nil,
+	}
+}
+
+func (f *CapabilitiesFlag) Type() string {
+	return "string"
+}
+
+func (f *CapabilitiesFlag) String() string {
+	return f.path
+}
+
+func (f *CapabilitiesFlag) Set(s string) error {
+	f.path = s
+	fd, err := os.Open(s)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	f.C, err = ast.LoadCapabilitiesJSON(fd)
+	return err
+}


### PR DESCRIPTION
### What this does
We want to replace the `opa build` command internally with this command. From testing, it looks like we're missing the `--capabilities` flag so this PR adds that flag and tests it.

### Notes for the reviewer
The code was inspired by https://github.com/open-policy-agent/opa/blob/v0.31.0/cmd/build_test.go, until we have a common library to use. I've tested in with our internal rules and it works.

**Note** I also need to update the public docs.

### More information

- [Jira ticket CFG-1091](https://snyksec.atlassian.net/browse/CFG-1091)

