### PR TITLE
Docs/update readme with diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 # About
 The SDK is a tool for writing, debugging, testing, and bundling custom rules for [Snyk Infrastructure as Code](https://snyk.io/product/infrastructure-as-code-security/). See our [Custom Rules documentation](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules) to learn more.
 
+![system overview](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.github.com/snyk/snyk-iac-rules/main/assets/overview-activity-swimlanes.puml)
+
 # Install
 The SDK can be installed through multiple channels.
 

--- a/assets/overview-activity-swimlanes.puml
+++ b/assets/overview-activity-swimlanes.puml
@@ -1,0 +1,30 @@
+@startuml
+skinparam activity {
+    FontColor          white
+    AttributeFontColor white
+    FontSize           14
+    AttributeFontSize  14
+    AttributeFontname  Corbel
+    BackgroundColor    #527BC6
+    BorderColor        black
+    ArrowColor         #222266
+}
+skinparam activityDiamondFontSize 14
+skinparam activityArrowFontSize 12
+
+|Development|
+start
+    :generate templates;
+    :write a rule in Rego;
+|Unit Testing|
+    :prepare a fixture file;
+    :write unit tests for the rule;
+    :run the tests against a fixture file;
+    #c69d52:while (do tests pass?) is (no)
+      :update tests/rule;
+    endwhile (yes)
+|Distribution|
+    :build the bundle;
+    :push the bundle;
+    stop
+@enduml

--- a/assets/overview-activity-vertical.puml
+++ b/assets/overview-activity-vertical.puml
@@ -1,0 +1,31 @@
+@startuml
+skinparam activity {
+    FontColor          white
+    AttributeFontColor white
+    FontSize           15
+    AttributeFontSize  15
+    AttributeFontname  Corbel
+    BackgroundColor    #527BC6
+    BorderColor        black
+    ArrowColor         #222266
+}
+partition "snyk-iac-rules " {
+    start
+    partition "development " {
+        :generate templates;
+        :write a rule in Rego;
+        partition "unit testing " {
+            :prepare a fixture file;
+            :write unit tests for the rule;
+            :run the tests against a fixture file;
+            #c69d52:while (do tests pass?) is (no)
+              :update tests/rule;
+            endwhile (yes)
+        }
+        :build the bundle;
+        :push the bundle;
+        stop
+    }
+
+}
+@enduml

--- a/assets/overview-activtiy-horizontal.puml
+++ b/assets/overview-activtiy-horizontal.puml
@@ -1,0 +1,33 @@
+@startuml
+skinparam activity {
+    FontColor          white
+    AttributeFontColor white
+    FontSize           15
+    AttributeFontSize  15
+    AttributeFontname  Corbel
+    BackgroundColor    #527BC6
+    BorderColor        black
+    ArrowColor         #222266
+}
+
+partition snyk/iac-rules {
+    partition development {
+        (*) -r> "generate templates"
+        -r>"write a rule in Rego"
+        partition unit-testing {
+              -r> "prepare a fixture file"
+              -r> "write unit tests for the rule"
+              -r> "run the tests against a fixture file"
+        }
+    }
+    ---> if "        do the tests pass?" then
+    partition distribution {
+        --->[ yes] "build the bundle"
+        -r> "push the bundle to a container registry"
+        -r> (*)
+    }
+    else
+        endif
+    --> [ no] "write unit tests for the rule"
+}
+@enduml


### PR DESCRIPTION
### What this does

This PR uploads a UML diagram around the usage of the tooling. This is placed in the `assets` folder.
We then integrate it into the Readme by using a proxy with no cache (so that the image can be rendered again if it changes) 

### Notes for the reviewer

Ran the e2e flow and the assets folder does not cause any issues.