### PR TITLE
test: update env vars for snyk contract test [CFG-1165]

### DIFF
--- a/spec/support/bin/@registry_test
+++ b/spec/support/bin/@registry_test
@@ -10,9 +10,9 @@
 snyk auth $SNYK_TOKEN 
 
 # set environment variables for the CLI
-export OCI_REGISTRY_URL=$1
-export OCI_REGISTRY_USERNAME=$2
-export OCI_REGISTRY_PASSWORD=$3
+snyk config set oci-registry-url=$1
+snyk config set oci-registry-username=$2
+snyk config set oci-registry-password=$3
 
 # use bundle with Snyk
 snyk iac test $4


### PR DESCRIPTION
### What this does
In https://github.com/snyk/snyk/pull/2336 we updated the CLI to use `snyk config set` for the OCI registry environment variables. This PR updates the code in the contract test so that it works with these new env vars.

### More information

- [Jira ticket CFG-1165](https://snyksec.atlassian.net/browse/CFG-1165)