### PR TITLE
chore: don't push tag if already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,11 @@ jobs:
           sudo apt update
           sudo apt install svu
           NEW_TAG=$(svu)
-          echo "NEW_TAG=${NEW_TAG}" >> $GITHUB_ENV
+          if [ $(git tag -l "$NEW_TAG") ]; then
+              echo "Tag already exists!"
+          else
+              echo "NEW_TAG=${NEW_TAG}" >> $GITHUB_ENV
+          fi
 
       - name: Push a new GitHub tag
         if: "!contains(github.ref, 'refs/tags/v${{env.NEW_TAG}}')"


### PR DESCRIPTION
### What this does

When we release a version of the SDK that only have `chore`, `test`, `refactor`, `svu` does not generate a new tag, it still uses the old tag. We then try to push it to GitHub again, causing a failure. This modifies the release workflow so that if the tag generated by the `svu` command can be found in GitHub, then we do not set the  `NEW_TAG` environment variable. The rest of the steps run if `NEW_TAG` is set, so we should not fail anymore.

**Note** I have not tested this in the workflow but I tested it locally:
![Screenshot 2021-11-08 at 19 14 12](https://user-images.githubusercontent.com/81559517/140803549-03073bfd-185e-47f5-a8db-70f5274d30eb.png)
![Screenshot 2021-11-08 at 19 14 30](https://user-images.githubusercontent.com/81559517/140803553-c462a514-0891-4b74-b69e-2645dda318a6.png)


