### PR TITLE
test: add contract test for github cr [CFG-1105]

### DIFF
--- a/.github/workflows/registries.yml
+++ b/.github/workflows/registries.yml
@@ -95,3 +95,33 @@ jobs:
           OCI_HARBOR_REGISTRY_URL: ${{ secrets.OCI_HARBOR_REGISTRY_URL }}
           OCI_HARBOR_REGISTRY_USERNAME: ${{ secrets.OCI_HARBOR_REGISTRY_USERNAME }}
           OCI_HARBOR_REGISTRY_PASSWORD: ${{ secrets.OCI_HARBOR_REGISTRY_PASSWORD }}
+
+  github:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup
+        uses: ./.github/actions/setup_shellspec # use local action
+
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.OCI_GITHUB_REGISTRY_USERNAME }}
+          password: ${{ secrets.OCI_GITHUB_REGISTRY_PASSWORD }}
+
+      - name: Run shellspec tests
+        working-directory: ./
+        shell: bash -l {0} # run bash with --login flag to load .bash_profile that's used by yarn install method
+        run: |
+          export PATH="/usr/local/bin/snyk-mac/docker:$PATH"
+
+          shellspec "spec/registries"
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          OCI_GITHUB_REGISTRY_NAME: ${{ secrets.OCI_GITHUB_REGISTRY_NAME }}
+          OCI_GITHUB_REGISTRY_URL: ${{ secrets.OCI_GITHUB_REGISTRY_URL }}
+          OCI_GITHUB_REGISTRY_USERNAME: ${{ secrets.OCI_GITHUB_REGISTRY_USERNAME }}
+          OCI_GITHUB_REGISTRY_PASSWORD: ${{ secrets.OCI_GITHUB_REGISTRY_PASSWORD }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -164,6 +164,11 @@ export OCI_HARBOR_REGISTRY_URL=
 export OCI_HARBOR_REGISTRY_NAME=
 export OCI_HARBOR_REGISTRY_USERNAME=
 export OCI_HARBOR_REGISTRY_PASSWORD=
+
+export OCI_GITHUB_REGISTRY_URL=
+export OCI_GITHUB_REGISTRY_NAME=
+export OCI_GITHUB_REGISTRY_USERNAME=<GitHub username>
+export OCI_GITHUB_REGISTRY_PASSWORD=<personal access token>
 ```
 
 Finally, run `shellspec "spec/registries"` to verify if the generated bundle from the SDK is valid for the Snyk CLI.

--- a/spec/registries/e2e_spec.sh
+++ b/spec/registries/e2e_spec.sh
@@ -48,4 +48,13 @@ Describe 'Supported Registry'
             The output should include 'Missing tags [Low Severity] [CUSTOM-1]' # it should include the custom rule in its output
         End
     End
+
+    Describe "GitHub"
+        Skip if 'environment variable is not set'  [ -z "$OCI_GITHUB_REGISTRY_URL" ]
+        It "can push and pull"
+            When call registry_test "$OCI_GITHUB_REGISTRY_NAME" "$OCI_GITHUB_REGISTRY_URL" "$OCI_GITHUB_REGISTRY_USERNAME" "$OCI_GITHUB_REGISTRY_PASSWORD"
+            The status should eq 1
+            The output should include 'Missing tags [Low Severity] [CUSTOM-1]' # it should include the custom rule in its output
+        End
+    End
 End


### PR DESCRIPTION
### What this does
This PR adds automated tests for GitHub CR. Next step will be to document that we support this in the public docs.

### Notes for the reviewer

To test locally, set the environment variables documented in the markdown and then run `shellspec "spec/registries"`:


![Screenshot 2021-11-11 at 08 23 16](https://user-images.githubusercontent.com/81559517/141263498-d9fa224c-b821-43ce-a9c9-4cfbee4fb05c.png)

Note that this doesn't run as part of the CI/CD for PRs, only when merged to `main`. The environment variables have been set in the tests and verified by temporarily running the GitHub action for this branch.

### More information

- [Jira ticket CFG-1105](https://snyksec.atlassian.net/browse/CFG-1105)

