### PR TITLE
chore: update cloud config to group iac ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/cloudconfig
+* @snyk/group-infrastructure-as-code


### PR DESCRIPTION
### What this does

Update code ownership as cloud config team grew to a group and changes its name to a wider scope.




