### PR TITLE
fix: Prohibited protocols in registries for push.

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -54,7 +54,12 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 			return fmt.Errorf("The provided container registry is invalid")
 		}
 
+		if strings.Contains(pushParams.BundleRegistry, "://") {
+			return fmt.Errorf("The provided container registry includes a protocol. Please remove it and try again")
+		}
+
 		repository := strings.Split(pushParams.BundleRegistry, "/")
+
 		tag := repository[len(repository)-1]
 		if !strings.Contains(tag, ":") {
 			pushParams.BundleRegistry = pushParams.BundleRegistry + ":latest"

--- a/spec/e2e/push_spec.sh
+++ b/spec/e2e/push_spec.sh
@@ -30,6 +30,15 @@ Describe './snyk-iac-rules push -r docker.io/test/test test.jpg'
    End
 End
 
+Describe 'When call ./snyk-iac-rules push -r https://docker.io/test/test bundle.tar.gz'
+   It 'returns failing test status'
+      When call ./snyk-iac-rules push -r https://docker.io/test/test bundle.tar.gz
+      The status should be failure
+      The output should include 'The provided container registry includes a protocol. Please remove it and try again'
+      The stderr should be present
+   End
+End
+
 # This tries to push a non-existant bundle to a DockerHub container registry
 Describe './snyk-iac-rules push -r docker.io/test/test bundle-incorrect.tar.gz'
    It 'returns failing test status'


### PR DESCRIPTION
### What this does

- Prohibits adding protocols in the registry containers provided as arguments for the `push` command.

### Notes for the reviewer

#### How to test locally

1. Prepare a custom-rules bundle generated by the [Snyk custom-rules bundles generator](https://github.com/snyk/snyk-iac-rules). You can refer to [the docs](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/-MdwVZ6HOZriajCf5nXH/c/rcGL1hZooMgd9mG27qkq/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk) to learn how.
2. Push the generated bundle to an OCI registry, using a registry container path that contains a protocol (e.g.,  `https://registry/library/image:tag`). You can folllow in [these instructions](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/pushing-a-bundle) for pushing a custom rules bundle.
3. Confirm that the operation resulted with an error, and that the message is: `The provided container registry includes a protocol. Please remove it and try again`.
4. Use the `push` command again, this time without a protocol in the registry container path (e.g.,  `registry/library/image:tag`)
5. Confirm that the operation was resolved with no errors.
6. Confirm that the bundle was pushed successfully to the OCI registry.

### More information

- [Jira ticket CFG-1183](https://snyksec.atlassian.net/browse/CFG-1183)
- [Link to documentation](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/-MdwVZ6HOZriajCf5nXH/c/rcGL1hZooMgd9mG27qkq/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk)

