### PR TITLE
fix: add default paths for rules/ and lib/ folder

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -41,14 +41,17 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 	SilenceUsage: true,
 	PostRun: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			// add default path if not provided
+			// add default paths if none were provided
 			args = append(args, "rules/", "lib/")
 		}
-		util.CheckIfRunningInRootDirectory(args)
+		err := util.IsPointingAtTemplatedRules(args)
+		if err != nil {
+			fmt.Println(err.Error())
+		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			// add default path if not provided
+			// add default paths if none were provided
 			args = append(args, "rules/", "lib/")
 		}
 		err := internal.RunBuild(args, buildParams)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -13,7 +12,7 @@ import (
 var BuildIgnore = append(TestIgnore, "testing", "*_test.rego")
 
 var buildCommand = &cobra.Command{
-	Use:   "build [path]",
+	Use:   "build [path...]",
 	Short: "Build an OPA bundle",
 	Long: `Build an OPA bundle.
 
@@ -22,7 +21,7 @@ gzipped tarballs. Paths referring to directories are loaded recursively.
 
 To start, run:
 $ snyk-iac-rules build
-An optional path can be provided if the current directory contains more than just 
+An optional list of paths can be provided if the current directory contains more than just 
 the rules for the bundle.
 
 To ignore test files, use the '--ignore' flag:
@@ -40,25 +39,17 @@ See our documentation to learn more:
 https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/bundling-rules
 `,
 	SilenceUsage: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			return errors.New("Too many paths provided")
-		}
-		return nil
-	},
 	PostRun: func(cmd *cobra.Command, args []string) {
-		var path string
 		if len(args) == 0 {
-			path = "."
-		} else {
-			path = args[0]
+			// add default path if not provided
+			args = append(args, "rules/", "lib/")
 		}
-		util.CheckIfRunningInRootDirectory(path)
+		util.CheckIfRunningInRootDirectory(args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			// add default path if not provided
-			args = append(args, ".")
+			args = append(args, "rules/", "lib/")
 		}
 		err := internal.RunBuild(args, buildParams)
 		if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -16,7 +15,7 @@ var TestIgnore = []string{
 }
 
 var testCommand = &cobra.Command{
-	Use:   "test [path]",
+	Use:   "test [path...]",
 	Short: "Execute Rego test cases",
 	Long: `Execute Rego test cases.
 
@@ -25,7 +24,8 @@ Test cases are rules whose names have the prefix "test_".
 
 To start, run:
 $ snyk-iac-rules test
-An optional path can be provided if the current directory contains more than just the rules for the bundle.
+An optional list of paths can be provided if the current directory contains more than just 
+the rules for the bundle.
 
 The command can run one test at a time with the help of the --run flag as such:
 $ snyk-iac-rules test --run test_<rule>
@@ -40,12 +40,6 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 `,
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			return errors.New("Too many paths provided")
-		}
-		return nil
-	},
 	PreRunE: func(Cmd *cobra.Command, args []string) error {
 		// If an --explain flag was set, turn on verbose output
 		if testParams.Explain.IsSet() {
@@ -55,18 +49,16 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 		return nil
 	},
 	PostRun: func(cmd *cobra.Command, args []string) {
-		var path string
 		if len(args) == 0 {
-			path = "."
-		} else {
-			path = args[0]
+			// add default path if not provided
+			args = append(args, "rules/", "lib/")
 		}
-		util.CheckIfRunningInRootDirectory(path)
+		util.CheckIfRunningInRootDirectory(args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			// add default path if not provided
-			args = append(args, ".")
+			args = append(args, "rules/", "lib/")
 		}
 		return internal.RunTest(args, testParams)
 	},

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -50,14 +51,17 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 	},
 	PostRun: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			// add default path if not provided
+			// add default paths if none were provided
 			args = append(args, "rules/", "lib/")
 		}
-		util.CheckIfRunningInRootDirectory(args)
+		err := util.IsPointingAtTemplatedRules(args)
+		if err != nil {
+			fmt.Println(err.Error())
+		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			// add default path if not provided
+			// add default paths if none were provided
 			args = append(args, "rules/", "lib/")
 		}
 		return internal.RunTest(args, testParams)

--- a/spec/e2e/build_spec.sh
+++ b/spec/e2e/build_spec.sh
@@ -8,7 +8,7 @@ Describe './snyk-iac-rules build --help'
       When call ./snyk-iac-rules build --help
       The status should be success
       The output should include 'Usage:
-  snyk-iac-rules build [path] [flags]
+  snyk-iac-rules build [path...] [flags]
 
 Flags:
   -c, --capabilities string   set configurable set of OPA capabilities
@@ -25,13 +25,24 @@ Describe './snyk-iac-rules build ./fixtures/custom-rules --ignore testing --igno
       When call ./snyk-iac-rules build ./fixtures/custom-rules --ignore testing --ignore "*_test.rego"
       The status should be success
       The output should include 'Generated bundle: bundle.tar.gz'
+      The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
    End
 End
 
-Describe './snyk-iac-rules build ./fixtures--ignore testing --ignore "*_test.rego"'
+Describe './snyk-iac-rules build ./fixtures --ignore testing --ignore "*_test.rego"'
    It 'returns passing test status'
       When call ./snyk-iac-rules build ./fixtures --ignore testing --ignore "*_test.rego"
       The status should be success
+      The output should include 'Generated bundle: bundle.tar.gz'
       The output should include 'WARNING: The command must point at a folder that contains the package for the rules'
+   End
+End
+
+Describe './snyk-iac-rules build ./fixtures/custom-rules/rules ./fixtures/custom-rules/lib --ignore testing --ignore "*_test.rego"'
+   It 'returns passing test status'
+      When call ./snyk-iac-rules build ./fixtures/custom-rules/rules ./fixtures/custom-rules/lib --ignore testing --ignore "*_test.rego"
+      The status should be success
+      The output should include 'Generated bundle: bundle.tar.gz'
+      The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
    End
 End

--- a/spec/e2e/test_spec.sh
+++ b/spec/e2e/test_spec.sh
@@ -5,7 +5,7 @@ Describe './snyk-iac-rules test --help'
       When call ./snyk-iac-rules test --help
       The status should be success
       The output should include 'Usage:
-  snyk-iac-rules test [path] [flags]
+  snyk-iac-rules test [path...] [flags]
 
 Flags:
       --explain {fails,full,notes}   enable query explanations (default fails)
@@ -22,6 +22,7 @@ Describe './snyk-iac-rules test ./fixtures/custom-rules'
       When call ./snyk-iac-rules test ./fixtures/custom-rules
       The status should be success
       The output should include 'PASS: 3/3'
+      The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
    End
 End
 
@@ -30,6 +31,7 @@ Describe './snyk-iac-rules test ./fixtures/custom-rules --run test_CUSTOM_1'
       When call ./snyk-iac-rules test ./fixtures/custom-rules --run test_CUSTOM_1
       The status should be success
       The output should include 'PASS: 1/1'
+      The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
    End
 End
 
@@ -38,5 +40,14 @@ Describe './snyk-iac-rules test ./fixtures --run test_CUSTOM_1'
       When call ./snyk-iac-rules test ./fixtures --run test_CUSTOM_1
       The status should be success
       The output should include 'WARNING: The command must point at a folder that contains the package for the rules'
+   End
+End
+
+Describe './snyk-iac-rules test ./fixtures/custom-rules/rules ./fixtures/custom-rules/lib'
+   It 'returns passing test status'
+      When call ./snyk-iac-rules test ./fixtures/custom-rules/rules ./fixtures/custom-rules/lib
+      The status should be success
+      The output should include 'PASS: 3/3'
+      The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
    End
 End

--- a/util/file_system.go
+++ b/util/file_system.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 )
 
 func checkIfDirectoryExists(path string) (bool, error) {
@@ -73,9 +74,18 @@ func ValidateFilePath(path string) (fs.FileInfo, error) {
 	return fileInfo, nil
 }
 
-func CheckIfRunningInRootDirectory(path string) {
-	_, err := os.Stat(computePath(path, "rules/"))
-	if err != nil && os.IsNotExist(err) {
-		fmt.Println("WARNING: The command must point at a folder that contains the package for the rules.\n	 If the rules were generated using the template command, make sure you have the\n	 /rules and /lib folder in your current running directory or provide an optional path argument pointing to that location.")
+func CheckIfRunningInRootDirectory(paths []string) {
+	for _, providedPath := range paths {
+		// the user can provide the path to the rules folder
+		if strings.HasSuffix(providedPath, "/rules") {
+			return
+		}
+		// otherwise, check that the path contains the rules folder
+		_, err := os.Stat(computePath(providedPath, "rules/"))
+		if err == nil || !os.IsNotExist(err) {
+			return
+		}
 	}
+	// TODO: what if not templated
+	fmt.Println("WARNING: The command must point at a folder that contains the package for the rules.\n	 If the rules were generated using the template command, make sure you have the\n	 /rules and /lib folder in your current running directory or provide an optional path argument pointing to that location.")
 }

--- a/util/file_system.go
+++ b/util/file_system.go
@@ -74,18 +74,20 @@ func ValidateFilePath(path string) (fs.FileInfo, error) {
 	return fileInfo, nil
 }
 
-func CheckIfRunningInRootDirectory(paths []string) {
+func IsPointingAtTemplatedRules(paths []string) error {
 	for _, providedPath := range paths {
+		var computedPath string
 		// the user can provide the path to the rules folder
 		if strings.HasSuffix(providedPath, "/rules") {
-			return
+			computedPath = providedPath
+		} else {
+			computedPath = computePath(providedPath, "rules/")
 		}
-		// otherwise, check that the path contains the rules folder
-		_, err := os.Stat(computePath(providedPath, "rules/"))
+		// still check that the path actually exists
+		_, err := os.Stat(computedPath)
 		if err == nil || !os.IsNotExist(err) {
-			return
+			return nil
 		}
 	}
-	// TODO: what if not templated
-	fmt.Println("WARNING: The command must point at a folder that contains the package for the rules.\n	 If the rules were generated using the template command, make sure you have the\n	 /rules and /lib folder in your current running directory or provide an optional path argument pointing to that location.")
+	return fmt.Errorf("WARNING: The command must point at a folder that contains the package for the rules.\n	 If the rules were generated using the template command, make sure you have the\n	 /rules and /lib folder in your current running directory or provide an optional path argument pointing to that location.")
 }

--- a/util/file_system_test.go
+++ b/util/file_system_test.go
@@ -114,3 +114,11 @@ func TestComputePath(t *testing.T) {
 	assert.Equal(t, "workingDirectory/name", computePath("./workingDirectory", "name"))
 	assert.Equal(t, "../workingDirectory/name", computePath("../workingDirectory", "name"))
 }
+
+func TestIsPointingAtTemplatedRules(t *testing.T) {
+	assert.NotNil(t, IsPointingAtTemplatedRules([]string{"../fixtures/rules"}))
+	assert.NotNil(t, IsPointingAtTemplatedRules([]string{"../fixtures"}))
+	assert.Nil(t, IsPointingAtTemplatedRules([]string{"../fixtures/custom-rules/rules"}))
+	assert.Nil(t, IsPointingAtTemplatedRules([]string{"invalid-path", "../fixtures/custom-rules/rules"}))
+	assert.Nil(t, IsPointingAtTemplatedRules([]string{"invalid-path", "../fixtures/custom-rules"}))
+}


### PR DESCRIPTION
### What this does

This PR makes two changes:
1. The `test` and `build `command accept multiple paths, so that users of the SDK can point at the exact folders they have their rules and helper functions in
2. The two commands use `rules/` and `lib/` as the default paths for the above change, so that it works from the get go

### Notes for the reviewer
There's a bit of duplication but other than pulling 
```
if len(args) == 0 {
			// add default path if not provided
			args = append(args, "rules/", "lib/")
}
```
into a function I can't think of a nice way to de-duplicate while still keeping the code readable.
Suggestions are welcome.

### More information

- [Slack thread](https://snyk.slack.com/archives/CMM9V3XPY/p1637910095232200)

