### PR TITLE
Include acknowledgements.tar.gz with release [CFG-1245]

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,6 +65,9 @@ release:
     ## Thanks!
 
     Those were the changes on {{ .Tag }}!
+    
+  extra_files:
+    glob: ./acknowledgements.tar.gz
 
 brews:
   -

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,10 @@ project_name: snyk-iac-rules
 before:
   hooks:
     - go mod tidy
+    - go get github.com/google/go-licenses
+    - go-licenses save . --save_path=./acknowledgements
+    - tar -cvf ./acknowledgements.tar.gz -C ./acknowledgements .
+    - rm -rf ./acknowledgements
 
 builds:
   - main: ./main.go
@@ -65,9 +69,9 @@ release:
     ## Thanks!
 
     Those were the changes on {{ .Tag }}!
-    
+
   extra_files:
-    glob: ./acknowledgements.tar.gz
+    - glob: ./acknowledgements.tar.gz
 
 brews:
   -


### PR DESCRIPTION
### What this does

This is part of our OSS license compliance, we need to include the licence/copyright information and in the case of the MPL2.0 licence for hashicorp/hcl the entire sourcecode alongside our distribution. Fortunately the [go-licenses](https://github.com/google/go-licenses) package handles this for us and will generate a directory containing all the relevant documents to comply with the dependency licences. We then tarball this and include it with the releases.

### Notes for the reviewer

I've tested this locally by running:

    goreleaser release --snapshot --rm-dist
    
Which confirms the tarball is created correctly, what I cannot confirm, but have reasonable confidence will work is the final `release.extra_files` step which should then upload the acknowledgements.tar.gz alongside the other files in the release.  

### More information

- [CFG-1245]



[CFG-1245]: https://snyksec.atlassian.net/browse/CFG-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ