### PR TITLE
fix: check for rules folder in current path

### DIFF
--- a/spec/contract/snyk_spec.sh
+++ b/spec/contract/snyk_spec.sh
@@ -38,6 +38,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
             The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
             The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
             The stderr should not be present
 
             cd ../
@@ -80,6 +81,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
             The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
             The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
             The stderr should not be present
         End
     End
@@ -116,6 +118,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
             The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
             The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
             The stderr should not be present
 
             cd ../

--- a/util/file_system.go
+++ b/util/file_system.go
@@ -6,7 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"strings"
+	"path/filepath"
 )
 
 func checkIfDirectoryExists(path string) (bool, error) {
@@ -78,7 +78,7 @@ func IsPointingAtTemplatedRules(paths []string) error {
 	for _, providedPath := range paths {
 		var computedPath string
 		// the user can provide the path to the rules folder
-		if strings.HasSuffix(providedPath, "/rules") {
+		if filepath.Base(providedPath) == "rules" {
 			computedPath = providedPath
 		} else {
 			computedPath = computePath(providedPath, "rules/")

--- a/util/file_system_test.go
+++ b/util/file_system_test.go
@@ -116,6 +116,7 @@ func TestComputePath(t *testing.T) {
 }
 
 func TestIsPointingAtTemplatedRules(t *testing.T) {
+	assert.NotNil(t, IsPointingAtTemplatedRules([]string{"../fixtures/rules/"}))
 	assert.NotNil(t, IsPointingAtTemplatedRules([]string{"../fixtures/rules"}))
 	assert.NotNil(t, IsPointingAtTemplatedRules([]string{"../fixtures"}))
 	assert.Nil(t, IsPointingAtTemplatedRules([]string{"../fixtures/custom-rules/rules"}))


### PR DESCRIPTION
### What this does

If the user provides a path like `rules/` then we would throw a warning. Instead of checking the path has a suffix, instead we compute the base of the path and see if it's `rules`
