### PR TITLE
test: Add custom rules message to e2e tests

### DIFF
--- a/spec/contract/snyk_spec.sh
+++ b/spec/contract/snyk_spec.sh
@@ -36,6 +36,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "Generated template" # the rule was tempalted successfully
             The output should include "PASS: 1/1" # the tests passed
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
+            The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
             The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
             The stderr should not be present
 
@@ -77,6 +78,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "Generated template" # the rule was tempalted successfully
             The output should include "PASS: 1/1" # the tests passed
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
+            The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
             The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
             The stderr should not be present
         End
@@ -112,6 +114,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "Generated template" # the rule was tempalted successfully
             The output should include "PASS: 1/1" # the tests passed
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
+            The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
             The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
             The stderr should not be present
 


### PR DESCRIPTION
### What this does
- Adds tests for the existence of the new user message added to the Snyk CLI for custom rules.

### Background context
When users apply custom rules bundles in the Snyk CLI, a new message now appears: "Using custom rules to generate misconfigurations.".
We'd like to add this message to our contract tests.

### More Information
- [PR with user message](https://github.com/snyk/snyk/pull/2393)
- [Slack thread](https://snyk.slack.com/archives/C022H54L8PJ/p1638293346269500)

