### PR TITLE
fix: npm package installation for npm 16.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           ./scripts/release-npm.sh --tag=v0.0.1
 
-          npm i -g dist
+          npm i -g ./dist
 
           # verifies that the installation works
           snyk-iac-rules
@@ -116,7 +116,7 @@ jobs:
 
           npm install -g npm
 
-          npm install -g dist
+          npm install -g ./dist
           
           # verifies that the installation works
-          C:/npm/prefix/dist
+          snyk-iac-rules

--- a/packaging/npm/passthrough.js
+++ b/packaging/npm/passthrough.js
@@ -11,7 +11,7 @@ var arch = process.arch;
 // file descriptors.
 var iacCustomRulesPath = path.join(__dirname, './snyk-iac-rules-' + os + '-' + arch);
 if (os === 'win32') {
-  iacCustomRulesPath = path.join(__dirname, './snyk-iac-rules.exe');
+  iacCustomRulesPath = path.join(__dirname, './snyk-iac-rules-win.exe');
 }
 
 try {

--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -38,7 +38,7 @@ for GOOS in linux darwin; do
     GOOS=$GOOS GOARCH=amd64 go build -a -o dist/snyk-iac-rules-$GOOS-x64 .
     GOOS=$GOOS GOARCH=arm64 go build -a -o dist/snyk-iac-rules-$GOOS-arm64 .
 done
-GOOS=windows GOARCH=amd64 go build -a -o dist/snyk-iac-rules.exe .
+GOOS=windows GOARCH=amd64 go build -a -o dist/snyk-iac-rules-win.exe .
 
 cp packaging/npm/passthrough.js dist/snyk-iac-rules
 cp README.md dist/README.md


### PR DESCRIPTION
### What this does

Fixes 'npm install' E2E tests on MacOS.

Fixed 'npm install' E2E tests on Windows, Windows test did not run(or show the output) snyk-iac-rules binary


### More information

- [Jira ticket CFG-1250](https://snyksec.atlassian.net/browse/CFG-1250)

