### PR TITLE
chore: fix registries tests

### DIFF
--- a/fixtures/custom-rules/rules/CUSTOM-4/main.rego
+++ b/fixtures/custom-rules/rules/CUSTOM-4/main.rego
@@ -3,7 +3,6 @@ package rules
 import data.lib
 
 deny[msg] {
-    trace(sprintf("input.resource == %s", [input.resource]))
 	resource := input.resource.aws_vpc[name]
     not resource.tags.owner
 


### PR DESCRIPTION
Forgot a `trace` in the rego rule and it was causing the CLI to fail with the following message:
![Screenshot 2021-12-07 at 09 57 30](https://user-images.githubusercontent.com/81559517/145007741-c2163a9c-52e2-427c-b508-aa2426b17ee1.png)


These tests run in `develop` only so that's why we didn't catch the failure inside a PR. 