### PR TITLE
refactor: snyk-iac-parsers import

### DIFF
--- a/builtins/hcl.go
+++ b/builtins/hcl.go
@@ -1,8 +1,9 @@
 package builtins
 
 import (
-	parsers "github.com/snyk/snyk-iac-parsers/pkg"
 	"io/ioutil"
+
+	parsers "github.com/snyk/snyk-iac-parsers"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"

--- a/builtins/terraform_plan.go
+++ b/builtins/terraform_plan.go
@@ -3,7 +3,7 @@ package builtins
 import (
 	"io/ioutil"
 
-	parsers "github.com/snyk/snyk-iac-parsers/pkg"
+	parsers "github.com/snyk/snyk-iac-parsers"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"

--- a/builtins/yaml.go
+++ b/builtins/yaml.go
@@ -1,8 +1,9 @@
 package builtins
 
 import (
-	parsers "github.com/snyk/snyk-iac-parsers/pkg"
 	"io/ioutil"
+
+	parsers "github.com/snyk/snyk-iac-parsers"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd v1.5.8
 	github.com/open-policy-agent/opa v0.32.0
 	github.com/opencontainers/image-spec v1.0.2
-	github.com/snyk/snyk-iac-parsers v0.0.5
+	github.com/snyk/snyk-iac-parsers v0.0.6
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	oras.land/oras-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/snyk-iac-parsers v0.0.5 h1:MZkst0tPhFii5xrKOBdooWRTisoiv92YnD4xFrtEsYE=
-github.com/snyk/snyk-iac-parsers v0.0.5/go.mod h1:v4bDVGe2aTcTywNmp0Ut6Bex7BWyPDnhCG27gQx8xck=
+github.com/snyk/snyk-iac-parsers v0.0.6 h1:Nr8OZ395iKEZMlJJq3WjzpyO3eg6FBHaVluVgy2hkb4=
+github.com/snyk/snyk-iac-parsers v0.0.6/go.mod h1:v4bDVGe2aTcTywNmp0Ut6Bex7BWyPDnhCG27gQx8xck=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	parsers "github.com/snyk/snyk-iac-parsers/pkg"
 	"io/ioutil"
+
+	parsers "github.com/snyk/snyk-iac-parsers"
 
 	"github.com/snyk/snyk-iac-rules/util"
 )


### PR DESCRIPTION
### What this does

This PR refactors the `snyk-iac-parsers` import after the functions were moved to the top-level of the Golang module.
