### PR TITLE
feat: add terraform plan fixture example [CFG-1204]

### DIFF
--- a/internal/template.go
+++ b/internal/template.go
@@ -99,6 +99,13 @@ func templateRule(workingDirectory string, templating util.Templating) error {
 		return err
 	}
 	fmt.Printf("[/] Template rules/%s/fixtures/denied2.tf file\n", templating.RuleID)
+
+	err = templateFile(ruleFixtureDir, "denied.json.tfplan", "templates/fixtures/denied.json.tfplan", templating)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("[/] Template rules/%s/fixtures/denied.json.tfplan file\n", templating.RuleID)
+
 	return nil
 }
 

--- a/internal/template_test.go
+++ b/internal/template_test.go
@@ -74,6 +74,11 @@ var files = []struct {
 		template:         "templates/fixtures/denied2.tf",
 	},
 	{
+		workingDirectory: "test/rules/Test Rule ID/fixtures",
+		name:             "denied.json.tfplan",
+		template:         "templates/fixtures/denied.json.tfplan",
+	},
+	{
 		workingDirectory: "test/lib",
 		name:             "main.rego",
 		template:         "templates/lib/main.tpl.rego",
@@ -224,7 +229,7 @@ func TestTemplateInDirectoryWithLibWithoutTfPlan(t *testing.T) {
 
 		// if creating the tfplan testing file then change its order
 		var oldFilesIndex int
-		if strings.Contains(name, "tfplan") {
+		if strings.Contains(name, "tfplan.rego") {
 			oldFilesIndex = filesIndex
 			filesIndex = len(files) - 1
 		}

--- a/spec/e2e/template_spec.sh
+++ b/spec/e2e/template_spec.sh
@@ -30,6 +30,7 @@ Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test'
       The output should include 'Template rules/test/fixtures/allowed.json file'
       The output should include 'Template rules/test/fixtures/denied1.yaml file'
       The output should include 'Template rules/test/fixtures/denied2.tf file'
+      The output should include 'Template rules/test/fixtures/denied.json.tfplan file'
       The output should include 'Generated template'
    End
 End

--- a/util/templates/fixtures/denied.json.tfplan
+++ b/util/templates/fixtures/denied.json.tfplan
@@ -1,0 +1,64 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.11",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "test.denied",
+          "mode": "managed",
+          "type": "test",
+          "name": "denied",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "todo": true
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "test.denied",
+      "mode": "managed",
+      "type": "test",
+      "name": "denied",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "todo": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "test.denied",
+          "mode": "managed",
+          "type": "test",
+          "name": "denied",
+          "provider_config_key": "aws",
+          "expressions": {},
+          "schema_version": 1
+        }
+      ]
+    }
+  }
+}

--- a/util/templates/main_test.tpl.rego
+++ b/util/templates/main_test.tpl.rego
@@ -17,6 +17,9 @@ test_{{ call .Replace .RuleID "-" "_" }} {
 	}, {
 		"want_msgs": ["input.resource.test[denied].todo"], # verifies that the correct msg is returned by the denied rule
 		"fixture": "denied1.yaml",
+	}, {
+		"want_msgs": ["input.resource.test[denied].todo"], # verifies that the correct msg is returned by the denied rule
+		"fixture": "denied.json.tfplan",
 	}]
 
 	test_cases := array.concat(allowed_test_cases, denied_test_cases)

--- a/util/templating_test.go
+++ b/util/templating_test.go
@@ -70,6 +70,9 @@ test_Test Rule ID {
 	}, {
 		"want_msgs": ["input.resource.test[denied].todo"], # verifies that the correct msg is returned by the denied rule
 		"fixture": "denied1.yaml",
+	}, {
+		"want_msgs": ["input.resource.test[denied].todo"], # verifies that the correct msg is returned by the denied rule
+		"fixture": "denied.json.tfplan",
 	}]
 
 	test_cases := array.concat(allowed_test_cases, denied_test_cases)


### PR DESCRIPTION
### What this does

This PR adds a fixture file example for Terraform Plan JSON output. The aim is to show what name the file must have (i.e. file extension `json.tfplan`), however the public docs will explain that the contents of the file itself will come from Terraform. The fixture file is also used in the actual tests so we know that when someone generates a new rule, all our formats are supported and tested from the beginning.

### More information

- [Jira ticket CFG-1204](https://snyksec.atlassian.net/browse/CFG-1204)

