### PR TITLE
fix: remove extra error log

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -51,13 +51,15 @@ $ snyk-iac-rules test --help
 		return nil
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		ruleId := strings.ToUpper(templateParams.RuleID)
+
 		// make sure rule name doesn't have any whitespace in it
-		if strings.Contains(templateParams.RuleID, " ") {
+		if strings.Contains(ruleId, " ") {
 			return fmt.Errorf("Rule name cannot contain whitespace")
 		}
 
 		// make sure rule name doesn't belong to Snyk namespace
-		if strings.HasPrefix(templateParams.RuleID, "SNYK-") {
+		if strings.HasPrefix(ruleId, "SNYK-") {
 			return fmt.Errorf("Rule name cannot start with \"SNYK-\"")
 		}
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/snyk/snyk-iac-rules/builtins"
@@ -14,7 +13,6 @@ func main() {
 	builtins.RegisterTerraformPlanBuiltin()
 
 	if err := cmd.RootCommand.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/spec/e2e/push_spec.sh
+++ b/spec/e2e/push_spec.sh
@@ -25,8 +25,7 @@ Describe './snyk-iac-rules push -r docker.io/test/test test.jpg'
    It 'returns failing test status'
       When call ./snyk-iac-rules push -r docker.io/test/test test.jpg
       The status should be failure
-      The output should include 'The path must be to a generated .tar.gz bundle'
-      The stderr should be present
+      The stderr should include 'The path must be to a generated .tar.gz bundle'
    End
 End
 
@@ -34,8 +33,7 @@ Describe 'When call ./snyk-iac-rules push -r https://docker.io/test/test bundle.
    It 'returns failing test status'
       When call ./snyk-iac-rules push -r https://docker.io/test/test bundle.tar.gz
       The status should be failure
-      The output should include 'The provided container registry includes a protocol. Please remove it and try again'
-      The stderr should be present
+      The stderr should include 'The provided container registry includes a protocol. Please remove it and try again'
    End
 End
 
@@ -44,8 +42,7 @@ Describe './snyk-iac-rules push -r docker.io/test/test bundle-incorrect.tar.gz'
    It 'returns failing test status'
       When call ./snyk-iac-rules push -r docker.io/test/test bundle-incorrect.tar.gz
       The status should be failure
-      The output should include 'Failed to read from the provided path'
-      The stderr should be present
+      The stderr should include 'Failed to read from the provided path'
    End
 End
 
@@ -53,8 +50,7 @@ Describe './snyk-iac-rules push -r test bundle.tar.gz'
    It 'returns failing test status'
       When call ./snyk-iac-rules push -r test bundle.tar.gz
       The status should be failure
-      The output should include 'The provided container registry is invalid'
-      The stderr should be present
+      The stderr should include 'The provided container registry is invalid'
    End
 End
 
@@ -64,8 +60,7 @@ Describe './snyk-iac-rules push -r docker.io/test/test bundle.tar.gz'
       When call ./snyk-iac-rules push -r docker.io/test/test bundle.tar.gz
       The status should be failure
       The output should include 'bundle.tar.gz'
-      The output should include 'Failed to push bundle to container registry: server message: insufficient_scope: authorization failed'
-      The stderr should be present
+      The stderr should include 'Failed to push bundle to container registry: server message: insufficient_scope: authorization failed'
    End
 End
 

--- a/spec/e2e/template_spec.sh
+++ b/spec/e2e/template_spec.sh
@@ -38,9 +38,8 @@ End
 Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test'
    It 'returns passing test status'
       When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test
-      Dump
       The status should be failure
-      The output should include 'Rule with the provided name already exists'
-      The stderr should be present
+      The output should include 'Template rules directory'
+      The stderr should include 'Rule with the provided name already exists'
    End
 End


### PR DESCRIPTION
### What this does

This PR has two changes:
1. Extra validation of the rule name, so it accounts for capitalisation
2. Removes extra logging so that we don't print out double the errorlogs

### Notes for the reviewer

This changes what gets printed out but since the error log was just duplicated we don't think this requires a major version release.

### More information

- Before
![Screenshot 2021-12-09 at 10 14 41](https://user-images.githubusercontent.com/81559517/145377515-b4f6079a-4950-457f-8166-8d478fa74054.png)
![Screenshot 2021-12-09 at 10 14 37](https://user-images.githubusercontent.com/81559517/145377522-98d07683-81cb-4e3d-b1c5-937b83deea67.png)
- After
![Screenshot 2021-12-09 at 10 14 12](https://user-images.githubusercontent.com/81559517/145377524-d9718442-e750-4523-a60c-5fb889db97c8.png)

