### PR TITLE
chore: use circle context for env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,12 @@ workflows:
                 - develop
       - security-oss:
           name: Snyk oss
+          context:
+            - snyk-iac-seceng
       - security-code:
           name: Snyk code
+          context:
+            - snyk-iac-seceng
       - regression-test:
           name: Regression Test
           filters:


### PR DESCRIPTION
### What this does

Switching env variable source to circle ci context


