### PR TITLE
feat: include metrics about number of custom rules [CFG-1133]

### DIFF
--- a/internal/build_test.go
+++ b/internal/build_test.go
@@ -310,15 +310,11 @@ func TestBuildProducesMetadata(t *testing.T) {
 			}
 			assert.Nil(t, err)
 
-			if f.Name == "/data.json" {
+			if f.Name == "/.manifest" {
 				data := new(bytes.Buffer)
 				_, err := data.ReadFrom(tr)
 				assert.Nil(t, err)
 				assert.Contains(t, data.String(), "{\"numberOfRules\":1}")
-			}
-
-			if f.Name == "/metadata.json" {
-				t.Fatal("unexpected file:", f.Name)
 			}
 		}
 	})


### PR DESCRIPTION
### What this does

This PR implements a way to get the rules that were written by a customer using the custom rules SDK. The `publicId` of the rule is what dictates the uniqueness/name of the rule, so we needed a way to parse the Rego files.

### Notes for the reviewer

- OPA introduced a new command called `inspect` which helps us find all the rego rules in a folder: https://github.com/open-policy-agent/opa/blob/main/cmd/inspect.go
- The majority of the code is not exposed in the Golang module so we are adapting a couple lines to read all the rego rules in a folder.
- The `inspect` command only looks at files and not the contents -  but we need a way to get the `publicId`
- The way we get the `publicId` is by reading each file and using a regex to extract the `publicId` which would be configured in a `publicId` key - the regex allows for any spacing so that no matter what tabbing and newline characters the customer uses, we will retrieve it
- The rules are computed and then their number is added to a temporary `metadata.json` file, which OPA includes then in the `data.json` as seen in the screenshot
![Screenshot 2021-12-13 at 17 20 51](https://user-images.githubusercontent.com/81559517/145862190-d6ecce58-9e9e-4a5b-b244-2b5abc0bc910.png)
- The `rules` section in the `data.json` file is generated automatically by OPA if there are json files, which there are under the `fixtures/` folder used for testing

### More information

- [Jira ticket CFG-1133](https://snyksec.atlassian.net/browse/CFG-1133)

