### PR TITLE
chore: add utility function for retrieving the rules in a bundle [CFG-1291]

### DIFF
--- a/util/inspect.go
+++ b/util/inspect.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"github.com/open-policy-agent/opa/loader"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func RetrieveRules(paths []string) ([]string, error) {
+	fileNames, err := findRegoFiles(paths)
+	if err != nil {
+		return []string{}, err
+	}
+
+	var publicIds = []string{}
+	for _, fileName := range fileNames {
+		publicId, err := getPublicIdFromFile(fileName)
+		if err != nil {
+			return []string{}, err
+		}
+		if publicId != "" {
+			publicIds = append(publicIds, publicId)
+		}
+	}
+	return publicIds, nil
+}
+
+func findRegoFiles(paths []string) ([]string, error) {
+	fileNames := []string{}
+
+	result, err := loader.AllRegos(paths)
+	if err != nil {
+		return fileNames, err
+	}
+
+	for _, module := range result.Modules {
+		fileName := filepath.Clean(module.Name)
+		if !strings.Contains(fileName, "_test.rego") {
+			fileNames = append(fileNames, fileName)
+		}
+	}
+
+	return fileNames, nil
+}
+
+func getPublicIdFromFile(fileName string) (string, error) {
+	data, err := os.ReadFile(fileName)
+	if err != nil {
+		return "", err
+	}
+
+	publicId := extractPublicIdFromRego(string(data))
+	return publicId, nil
+}
+
+func extractPublicIdFromRego(rego string) string {
+	re := regexp.MustCompile("\"publicId\"\\s*:\\s*\"(.*?)\"")
+	match := re.FindStringSubmatch(rego)
+	if len(match) > 0 {
+		return match[1]
+	}
+	return ""
+}

--- a/util/inspect_test.go
+++ b/util/inspect_test.go
@@ -1,0 +1,122 @@
+package util
+
+import (
+	"github.com/open-policy-agent/opa/util/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRetrieveRulesWitInvalidPath(t *testing.T) {
+	_, err := RetrieveRules([]string{"./invalid"})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "./invalid: no such file or directory")
+}
+
+func TestRetrieveRulesWithNoFiles(t *testing.T) {
+	files := map[string]string{}
+	test.WithTempFS(files, func(root string) {
+		rules, err := RetrieveRules([]string{root})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(rules))
+	})
+}
+
+func TestRetrieveRulesWithNoRules(t *testing.T) {
+	files := map[string]string{
+		"test.json": `
+			test
+		`,
+	}
+
+	test.WithTempFS(files, func(root string) {
+		rules, err := RetrieveRules([]string{root})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(rules))
+	})
+}
+
+func TestRetrieveRulesWithRulesWithoutPublicId(t *testing.T) {
+	files := map[string]string{
+		"test.rego": `
+			package test
+			msg = {
+				"publicI":
+					"1"
+			}
+		`,
+	}
+
+	test.WithTempFS(files, func(root string) {
+		rules, err := RetrieveRules([]string{root})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(rules))
+	})
+}
+
+func TestRetrieveRulesWithRulesWithDistinctPublicIds(t *testing.T) {
+	files := map[string]string{
+		"test1.rego": `
+			package test
+			msg = {
+				"publicId":
+					"1"
+			}
+		`,
+		"test2.rego": `
+			package test
+			msg = {
+				"publicId":
+					"2"
+			}
+		`,
+		"test2_test.rego": `
+			package test
+			msg = {
+				"publicId":
+					"3"
+			}
+		`,
+	}
+
+	test.WithTempFS(files, func(root string) {
+		rules, err := RetrieveRules([]string{root})
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(rules))
+		assert.Equal(t, "1", rules[0])
+		assert.Equal(t, "2", rules[1])
+	})
+}
+
+func TestRetrieveRulesWithRulesWithSamePublicIds(t *testing.T) {
+	files := map[string]string{
+		"test1.rego": `
+			package test
+			msg = {
+				"publicId":
+					"1"
+			}
+		`,
+		"test2.rego": `
+			package test
+			msg = {
+				"publicId":
+					"1"
+			}
+		`,
+		"test2_test.rego": `
+			package test
+			msg = {
+				"publicId":
+					"3"
+			}
+		`,
+	}
+
+	test.WithTempFS(files, func(root string) {
+		rules, err := RetrieveRules([]string{root})
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(rules))
+		assert.Equal(t, "1", rules[0])
+		assert.Equal(t, "1", rules[1])
+	})
+}


### PR DESCRIPTION
### What this does

This functionality was first introduced in https://github.com/snyk/snyk-iac-rules/pull/121 but that PR is blocked behind a bug in OPA. This PR extracts the utility function from that PR, which just retrieves the `publicId`s for all rego rules in a bundle - including duplicates.

### Notes for the reviewer

- OPA introduced a new command called `inspect` which helps us find all the rego rules in a folder: https://github.com/open-policy-agent/opa/blob/main/cmd/inspect.go
- The majority of the code is not exposed in the Golang module so we are adapting a couple lines to read all the rego rules in a folder.
- The `inspect` command only looks at files and not the contents -  but we need a way to get the `publicId`
- The way we get the `publicId` is by reading each file and using a regex to extract the `publicId` which would be configured in a `publicId` key - the regex allows for any spacing so that no matter what tabbing and newline characters the customer uses, we will retrieve it

### More information

- [Jira ticket CFG-1291](https://snyksec.atlassian.net/browse/CFG-1291)
