### PR TITLE
fix: add WORKDIR to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
+WORKDIR /app
 # Copy from the tmp directory created as part of the Docker release
 # this is equivalent to the /dist dir created by goreleaser.
 COPY ./snyk-iac-rules ./


### PR DESCRIPTION
### What this does

This PR adds a specific working directory to the docker image.
The change will enable us to run the SDK as a container while linking it to the local directory of the user by using:
`docker run --rm --mount source=$PWD,target=/app,type=bind snyk/snyk-iac-rules` 

