### PR TITLE
Fix the COPY and ENTRYPOINT in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM scratch
 WORKDIR /app
 # Copy from the tmp directory created as part of the Docker release
 # this is equivalent to the /dist dir created by goreleaser.
-COPY ./snyk-iac-rules ./
-ENTRYPOINT ["./snyk-iac-rules"]
+COPY ./snyk-iac-rules /usr/local/bin/
+ENTRYPOINT ["snyk-iac-rules"]


### PR DESCRIPTION
### What this does

This PR fixes the docker image by moving the snyk-iac-rules binary to a directory that is included in the PATH of the user (usr/local/bin).