### PR TITLE
chore: add job to lint commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,34 @@ jobs:
           monitor-on-build: false
           project: ${CIRCLE_PROJECT_REPONAME}
           organization: snyk-iac-group-seceng
+  lint_commit_message:
+    docker:
+      - image: circleci/node:14
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Define environment variable with lastest commit's message
+          command: |
+            npm install --save-dev @commitlint/config-conventional @commitlint/cli
+            echo "module.exports = {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
+            echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Lint commit message
+          command: echo "$COMMIT_MESSAGE" | npx commitlint
 workflows:
   version: 2
   test:
     jobs:
+      - lint_commit_message:
+          name: Lint commit message
+          filters:
+            branches:
+              ignore:
+                - main
+                - develop
       - lint_and_format:
           name: Lint & formatting
           filters:


### PR DESCRIPTION
### What this does

Adds a job to CircleCI for linting commit messages using https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional

The release process uses https://github.com/caarlos0/svu to create releases so it's important that we don't allow invalid commits through.

Failed for a `test commit`:
![Screenshot 2021-12-21 at 17 44 17](https://user-images.githubusercontent.com/81559517/146975078-42a4ad11-e4f7-4555-9cd2-614389b94196.png)

Succeeded for current commit:
![Screenshot 2021-12-21 at 17 50 24](https://user-images.githubusercontent.com/81559517/146975743-2e849500-8faa-4b8f-a6eb-50b7ad1c0e1e.png)

