### PR TITLE
chore: Specified the container latest version [CFG-1267]

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,7 +128,6 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-    - "snyk/{{ .ProjectName }}:latest"
     - "snyk/{{ .ProjectName }}:{{ .Version }}"
 
 announce:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn global add snyk-iac-rules
 [snyk-iac-rules available as a docker image](https://hub.docker.com/r/snyk/snyk-iac-rules). If you have Docker installed locally, you can install it by running:
 
 ```bash
-docker pull snyk/snyk-iac-rules:latest
+docker pull snyk/snyk-iac-rules:<version>
 ```
 
 You can then run the container like so:


### PR DESCRIPTION
### What this does

As part of the [instructions for securing container images published by Snyk](https://www.notion.so/snyk/Securing-container-images-published-by-Snyk-7c4863303572442bb5c3b96efc6184a5#7cbbe1b708a04d88ad98967e6c9eb8a8), we'd like to ensure that the [snyk/snyk-iac-rules](https://hub.docker.com/r/snyk/snyk-iac-rules) image contains only semver versions.
In order to accomplish that, we will make sure the `latest` tag is not used anywhere so that we can safely delete it on Docker Hub.
Instead, we will reference the actual latest version's tag, which is `1.2.0`.

### More information
[Jira ticket CFG-1267](https://snyksec.atlassian.net/browse/CFG-1267)
[Slack thread](https://snyk.slack.com/archives/CS61093QC/p1638959678001800)
[Notion - Securing container images published by Snyk](https://www.notion.so/snyk/Securing-container-images-published-by-Snyk-7c4863303572442bb5c3b96efc6184a5#7cbbe1b708a04d88ad98967e6c9eb8a8)