### PR TITLE
Fix: Prevent duplicate rules in bundle [CFG-1233]

### DIFF
--- a/internal/build_test.go
+++ b/internal/build_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -266,5 +267,35 @@ func TestBuildRespectsCapabilitiesFailure(t *testing.T) {
 		err := RunBuild([]string{root}, buildParams)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "undefined function is_foo")
+	})
+}
+
+func TestBuildWithDuplicateRuleIds(t *testing.T) {
+	baseTestFiles := map[string]string{
+		"test1.rego": `
+			package test
+			msg = {
+				"publicId": "TEST-1"
+			}
+		`,
+		"test2.rego": `
+			package test
+			msg = {
+				"publicId": "TEST-1"
+			}
+		`,
+	}
+
+	test.WithTempFS(baseTestFiles, func(root string) {
+		buildParams := mockBuildParams()
+		buildParams.OutputFile = path.Join(root, "bundle.tar.gz")
+		err := buildParams.Target.Set(TargetRego)
+		assert.Nil(t, err)
+
+		err = RunBuild([]string{root}, buildParams)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "The bundle contains duplicate rules")
+		assert.Contains(t, err.Error(), fmt.Sprintf("%s/test1.rego", root))
+		assert.Contains(t, err.Error(), fmt.Sprintf("%s/test2.rego", root))
 	})
 }

--- a/util/inspect.go
+++ b/util/inspect.go
@@ -1,30 +1,39 @@
 package util
 
 import (
-	"github.com/open-policy-agent/opa/loader"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/open-policy-agent/opa/loader"
 )
 
-func RetrieveRules(paths []string) ([]string, error) {
+type Rule struct {
+	PublicId string
+	Path     string
+}
+
+func RetrieveRules(paths []string) ([]Rule, error) {
 	fileNames, err := findRegoFiles(paths)
 	if err != nil {
-		return []string{}, err
+		return []Rule{}, err
 	}
 
-	var publicIds = []string{}
+	rules := []Rule{}
 	for _, fileName := range fileNames {
 		publicId, err := getPublicIdFromFile(fileName)
 		if err != nil {
-			return []string{}, err
+			return []Rule{}, err
 		}
 		if publicId != "" {
-			publicIds = append(publicIds, publicId)
+			rules = append(rules, Rule{
+				PublicId: publicId,
+				Path:     fileName,
+			})
 		}
 	}
-	return publicIds, nil
+	return rules, nil
 }
 
 func findRegoFiles(paths []string) ([]string, error) {

--- a/util/inspect_test.go
+++ b/util/inspect_test.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/open-policy-agent/opa/util/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestRetrieveRulesWitInvalidPath(t *testing.T) {
@@ -82,8 +84,16 @@ func TestRetrieveRulesWithRulesWithDistinctPublicIds(t *testing.T) {
 		rules, err := RetrieveRules([]string{root})
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(rules))
-		assert.Equal(t, "1", rules[0])
-		assert.Equal(t, "2", rules[1])
+		assert.Subset(t, rules, []Rule{
+			{
+				PublicId: "1",
+				Path:     fmt.Sprintf("%s/test1.rego", root),
+			},
+			{
+				PublicId: "2",
+				Path:     fmt.Sprintf("%s/test2.rego", root),
+			},
+		})
 	})
 }
 
@@ -116,7 +126,15 @@ func TestRetrieveRulesWithRulesWithSamePublicIds(t *testing.T) {
 		rules, err := RetrieveRules([]string{root})
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(rules))
-		assert.Equal(t, "1", rules[0])
-		assert.Equal(t, "1", rules[1])
+		assert.Subset(t, rules, []Rule{
+			{
+				PublicId: "1",
+				Path:     fmt.Sprintf("%s/test1.rego", root),
+			},
+			{
+				PublicId: "1",
+				Path:     fmt.Sprintf("%s/test2.rego", root),
+			},
+		})
 	})
 }


### PR DESCRIPTION
### What this does

- Asserts the inexistence of rules with the same public ID when building bundles. 

#### Background context

There is currently no validation to make sure a new rule doesn’t have the same public ID as an existing one. We have some in the template command - the rule id is used for the folder name so we error if the folder already exists. But we don’t stop users from changing the id afterward.

We'd like to ensure that generated bundles do not contain duplicate rules, that is, rules with the same public ID.

#### Notes for the reviewer
- Currently, we do not ensure that all public rule IDs are uppercased. In this implementation, the rule IDs comparison is done with case insensitivity. I've raised a question about it in this [Slack thread](https://snyk.slack.com/archives/C022H54L8PJ/p1640857469331600) to figure out if uppercased IDs is another matter we would like to ensure.

#### Where should the reviewer start?
- `internal/build.go:RunBuild`

### More information

- [Jira ticket CFG-1233](https://snyksec.atlassian.net/browse/CFG-1233)
- [Link to documentation](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules)

