### PR TITLE
Chore: Re-added latest tag for docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,6 +128,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
+    - "snyk/{{ .ProjectName }}:latest"
     - "snyk/{{ .ProjectName }}:{{ .Version }}"
 
 announce:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn global add snyk-iac-rules
 [snyk-iac-rules available as a docker image](https://hub.docker.com/r/snyk/snyk-iac-rules). If you have Docker installed locally, you can install it by running:
 
 ```bash
-docker pull snyk/snyk-iac-rules:<version>
+docker pull snyk/snyk-iac-rules:latest
 ```
 
 You can then run the container like so:


### PR DESCRIPTION
### What this does

- Reverts the changes from this #136, by re-adding the `latest` tag to the release flow for the `snyk/snyk-iac-rules` image.

### Notes for the reviewer

- Following a discussion with the [#proj-secure-public-client-images](https://snyk.slack.com/archives/C02GCNHTUAU) channel members, it has been confirmed that the `latest` tag for [snyk/snyk-iac-rules](https://hub.docker.com/repository/docker/snyk/snyk-iac-rules) can still be published as part of our release pipeline, as long as the semver versions for the image are updated correctly.
- It was originally removed as part of the instructions for [securing container images published by Snyk](https://www.notion.so/snyk/Securing-container-images-published-by-Snyk-7c4863303572442bb5c3b96efc6184a5#7cbbe1b708a04d88ad98967e6c9eb8a8), which recommend supporting only semver versions.

### More information

- The PR being reverted: #136 
- [Slack thread](https://snyk.slack.com/archives/C02GCNHTUAU/p1640597468160900)

