### PR TITLE
Fix: Assert uppercased rules in bundle [CFG-1343]

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -51,15 +52,20 @@ $ snyk-iac-rules test --help
 		return nil
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		ruleId := strings.ToUpper(templateParams.RuleID)
+		// make sure rule name is in uppercase
+		for _, r := range templateParams.RuleID {
+			if !unicode.IsUpper(r) && unicode.IsLetter(r) {
+				return fmt.Errorf("Rule name must be in uppercase")
+			}
+		}
 
 		// make sure rule name doesn't have any whitespace in it
-		if strings.Contains(ruleId, " ") {
+		if strings.Contains(templateParams.RuleID, " ") {
 			return fmt.Errorf("Rule name cannot contain whitespace")
 		}
 
 		// make sure rule name doesn't belong to Snyk namespace
-		if strings.HasPrefix(ruleId, "SNYK-") {
+		if strings.HasPrefix(templateParams.RuleID, "SNYK-") {
 			return fmt.Errorf("Rule name cannot start with \"SNYK-\"")
 		}
 

--- a/spec/contract/snyk_spec.sh
+++ b/spec/contract/snyk_spec.sh
@@ -15,7 +15,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
                 cd tmp
 
                 # create a basic rule
-                ../snyk-iac-rules template --rule Contract --format hcl2
+                ../snyk-iac-rules template --rule CONTRACT --format hcl2
 
                 # run tests and make sure they pass
                 ../snyk-iac-rules test
@@ -27,7 +27,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
                 snyk auth $SNYK_TOKEN 
 
                 # use bundle with Snyk
-                snyk iac test --rules=./bundle.tar.gz ./rules/Contract/fixtures/denied.tf
+                snyk iac test --rules=./bundle.tar.gz ./rules/CONTRACT/fixtures/denied.tf
                 echo $?
             }
 
@@ -37,7 +37,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "PASS: 1/1" # the tests passed
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
             The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
-            The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The output should include "Default title [Low Severity] [CONTRACT]" # it should include the custom rule in its output
             The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
             The stderr should not be present
 
@@ -47,14 +47,14 @@ Describe 'Contract test between the SDK and the Snyk CLI'
         It 'Verifies custom rule with relative path'
             snyk_iac_test() {
                 # create a basic rule
-                ./snyk-iac-rules template ./tmp --rule Contract --format hcl2
+                ./snyk-iac-rules template ./tmp --rule CONTRACT --format hcl2
 
                 OS=$(uname)
                 # replace the fixture path so it's correct
                 if [ "$OS" = "Darwin" ]; then
-                    sed -i '' -e 's#/rules/Contract/fixtures#/tmp/rules/Contract/fixtures#' ./tmp/rules/Contract/main_test.rego
+                    sed -i '' -e 's#/rules/CONTRACT/fixtures#/tmp/rules/CONTRACT/fixtures#' ./tmp/rules/CONTRACT/main_test.rego
                 else
-                    sed -i -e 's#/rules/Contract/fixtures#/tmp/rules/Contract/fixtures#' ./tmp/rules/Contract/main_test.rego
+                    sed -i -e 's#/rules/CONTRACT/fixtures#/tmp/rules/CONTRACT/fixtures#' ./tmp/rules/CONTRACT/main_test.rego
                 fi
 
                 # run tests and make sure they pass
@@ -67,7 +67,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
                 snyk auth $SNYK_TOKEN
 
                 # use bundle with Snyk
-                snyk iac test --rules=./bundle.tar.gz ./tmp/rules/Contract/fixtures/denied.tf
+                snyk iac test --rules=./bundle.tar.gz ./tmp/rules/CONTRACT/fixtures/denied.tf
                 echo $?
             }
 
@@ -77,7 +77,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "PASS: 1/1" # the tests passed
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
             The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
-            The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The output should include "Default title [Low Severity] [CONTRACT]" # it should include the custom rule in its output
             The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
             The stderr should not be present
         End
@@ -93,7 +93,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
                 cd tmp
 
                 # create a basic rule
-                ../snyk-iac-rules template --rule Contract --format hcl2
+                ../snyk-iac-rules template --rule CONTRACT --format hcl2
 
                 # run tests and make sure they pass
                 ../snyk-iac-rules test
@@ -104,7 +104,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
                 # push bundle
                 ../snyk-iac-rules push --registry $OCI_REGISTRY_NAME-$OS bundle.tar.gz
 
-                @registry_test https://registry-1.$OCI_REGISTRY_NAME-$OS $OCI_REGISTRY_USERNAME $OCI_REGISTRY_PASSWORD ./rules/Contract/fixtures/denied.tf
+                @registry_test https://registry-1.$OCI_REGISTRY_NAME-$OS $OCI_REGISTRY_USERNAME $OCI_REGISTRY_PASSWORD ./rules/CONTRACT/fixtures/denied.tf
                 echo $?
             }
 
@@ -114,7 +114,7 @@ Describe 'Contract test between the SDK and the Snyk CLI'
             The output should include "PASS: 1/1" # the tests passed
             The output should include "Generated bundle: bundle.tar.gz" # the bundle has been generated
             The output should include "Using custom rules to generate misconfigurations." # uses the custom rules to generate misconfigurations
-            The output should include "Default title [Low Severity] [Contract]" # it should include the custom rule in its output
+            The output should include "Default title [Low Severity] [CONTRACT]" # it should include the custom rule in its output
             The output should not include 'WARNING: The command must point at a folder that contains the package for the rules'
             The stderr should not be present
 

--- a/spec/e2e/formats_spec.sh
+++ b/spec/e2e/formats_spec.sh
@@ -18,11 +18,11 @@ Describe 'Verifies custom rules for all formats'
             cd tmp
 
             # create a basic rule
-            ../snyk-iac-rules template --rule Contract --format "$1"
+            ../snyk-iac-rules template --rule CONTRACT --format "$1"
 
             if [ "$1" != "json" ]; then
-                ../snyk-iac-rules parse ./rules/Contract/fixtures/denied"$2" --format "$1"
-                ../snyk-iac-rules parse ./rules/Contract/fixtures/allowed"$2" --format "$1"
+                ../snyk-iac-rules parse ./rules/CONTRACT/fixtures/denied"$2" --format "$1"
+                ../snyk-iac-rules parse ./rules/CONTRACT/fixtures/allowed"$2" --format "$1"
             fi
 
             # run tests and make sure they pass

--- a/spec/e2e/template_spec.sh
+++ b/spec/e2e/template_spec.sh
@@ -24,99 +24,99 @@ Describe './snyk-iac-rules template ./fixtures/custom-rules --format hcl2'
    End
 End
 
-Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test'
+Describe './snyk-iac-rules template ./fixtures/custom-rules --rule TEST'
    It 'returns  an error'
-      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test
+      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST
       The status should be failure
       The stderr should include 'required flag(s) "format" not set'
    End
 End
 
-Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test --format fake'
+Describe './snyk-iac-rules template ./fixtures/custom-rules --rule TEST --format fake'
    It 'returns  an error'
-      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test --format fake
+      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST --format fake
       The status should be failure
       The stderr should include 'invalid argument "fake" for "-f, --format" flag'
    End
 End
 
-Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test1 --format hcl2'
+Describe './snyk-iac-rules template ./fixtures/custom-rules --rule TEST1 --format hcl2'
    It 'generates the template'
-      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test1 --format hcl2
+      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST1 --format hcl2
       The status should be success
       The output should include 'Template rules directory'
-      The output should include 'Template rules/test1 directory'
-      The output should include 'Template rules/test1/main.rego file'
-      The output should include 'Template rules/test1/main_test.rego file'
-      The output should include 'Template rules/test1/fixtures directory'
-      The output should include 'Template rules/test1/fixtures/denied.tf file'
-      The output should include 'Template rules/test1/fixtures/allowed.tf file'
+      The output should include 'Template rules/TEST1 directory'
+      The output should include 'Template rules/TEST1/main.rego file'
+      The output should include 'Template rules/TEST1/main_test.rego file'
+      The output should include 'Template rules/TEST1/fixtures directory'
+      The output should include 'Template rules/TEST1/fixtures/denied.tf file'
+      The output should include 'Template rules/TEST1/fixtures/allowed.tf file'
       The output should include 'Generated template'
 
-      rm -rf ./fixtures/custom-rules/rules/test1
+      rm -rf ./fixtures/custom-rules/rules/TEST1
    End
 End
 
-Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test2 --format json'
+Describe './snyk-iac-rules template ./fixtures/custom-rules --rule TEST2 --format json'
    It 'generates the template'
-      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test2 --format json
+      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST2 --format json
       The status should be success
       The output should include 'Template rules directory'
-      The output should include 'Template rules/test2 directory'
-      The output should include 'Template rules/test2/main.rego file'
-      The output should include 'Template rules/test2/main_test.rego file'
-      The output should include 'Template rules/test2/fixtures directory'
-      The output should include 'Template rules/test2/fixtures/denied.json file'
-      The output should include 'Template rules/test2/fixtures/allowed.json file'
+      The output should include 'Template rules/TEST2 directory'
+      The output should include 'Template rules/TEST2/main.rego file'
+      The output should include 'Template rules/TEST2/main_test.rego file'
+      The output should include 'Template rules/TEST2/fixtures directory'
+      The output should include 'Template rules/TEST2/fixtures/denied.json file'
+      The output should include 'Template rules/TEST2/fixtures/allowed.json file'
       The output should include 'Generated template'
 
-      rm -rf ./fixtures/custom-rules/rules/test2
+      rm -rf ./fixtures/custom-rules/rules/TEST2
    End
 End
 
-Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test3 --format yaml'
+Describe './snyk-iac-rules template ./fixtures/custom-rules --rule TEST3 --format yaml'
    It 'returns passing test status'
-      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test3 --format yaml
+      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST3 --format yaml
       The status should be success
       The output should include 'Template rules directory'
-      The output should include 'Template rules/test3 directory'
-      The output should include 'Template rules/test3/main.rego file'
-      The output should include 'Template rules/test3/main_test.rego file'
-      The output should include 'Template rules/test3/fixtures directory'
-      The output should include 'Template rules/test3/fixtures/denied.yaml file'
-      The output should include 'Template rules/test3/fixtures/allowed.yaml file'
+      The output should include 'Template rules/TEST3 directory'
+      The output should include 'Template rules/TEST3/main.rego file'
+      The output should include 'Template rules/TEST3/main_test.rego file'
+      The output should include 'Template rules/TEST3/fixtures directory'
+      The output should include 'Template rules/TEST3/fixtures/denied.yaml file'
+      The output should include 'Template rules/TEST3/fixtures/allowed.yaml file'
       The output should include 'Generated template'
 
-      rm -rf ./fixtures/custom-rules/rules/test3
+      rm -rf ./fixtures/custom-rules/rules/TEST3
    End
 End
 
-Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test4 --format tf-plan'
+Describe './snyk-iac-rules template ./fixtures/custom-rules --rule TEST4 --format tf-plan'
    It 'returns passing test status'
-      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test4 --format tf-plan
+      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST4 --format tf-plan
       The status should be success
       The output should include 'Template rules directory'
-      The output should include 'Template rules/test4 directory'
-      The output should include 'Template rules/test4/main.rego file'
-      The output should include 'Template rules/test4/main_test.rego file'
-      The output should include 'Template rules/test4/fixtures directory'
-      The output should include 'Template rules/test4/fixtures/denied.json.tfplan file'
-      The output should include 'Template rules/test4/fixtures/allowed.json.tfplan file'
+      The output should include 'Template rules/TEST4 directory'
+      The output should include 'Template rules/TEST4/main.rego file'
+      The output should include 'Template rules/TEST4/main_test.rego file'
+      The output should include 'Template rules/TEST4/fixtures directory'
+      The output should include 'Template rules/TEST4/fixtures/denied.json.tfplan file'
+      The output should include 'Template rules/TEST4/fixtures/allowed.json.tfplan file'
       The output should include 'Generated template'
 
-      rm -rf ./fixtures/custom-rules/rules/test4
+      rm -rf ./fixtures/custom-rules/rules/TEST4
    End
 End
 
-Describe './snyk-iac-rules template ./fixtures/custom-rules --rule test4'
+Describe './snyk-iac-rules template ./fixtures/custom-rules --rule TEST4'
    It 'returns passing test status'
-      ./snyk-iac-rules template ./fixtures/custom-rules --rule test4 --format tf-plan
+      ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST4 --format tf-plan
 
-      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule test4 --format tf-plan
+      When call ./snyk-iac-rules template ./fixtures/custom-rules --rule TEST4 --format tf-plan
       The status should be failure
       The output should include 'Template rules directory'
       The stderr should include 'Rule with the provided name already exists'
 
-      rm -rf ./fixtures/custom-rules/rules/test4
+      rm -rf ./fixtures/custom-rules/rules/TEST4
    End
 End


### PR DESCRIPTION
### What this does

- Ensures uppercased public rule IDs for the `template` and `build` commands.

### Background context
Currently, there is no validation to ensure a new rule is uppercased in the `template` and `build` commands.
We’d like to add this assertion so that only uppercased IDs are permitted.

### Notes for the reviewer
- This assertion is similar to 2 other recently added assertions:
    - #138 
    - #137 
- The error message for the assertion [was approved by the user content team](https://snyksec.atlassian.net/browse/CFG-1343?focusedCommentId=261395).

### More information

- [CFG-1343](https://snyksec.atlassian.net/browse/CFG-1343)
- [Slack thread](https://snyk.slack.com/archives/C022H54L8PJ/p1640857469331600)
- [Link to docs](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules)

