### PR TITLE
Chore: Added license issue to .snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'snyk:lic:golang:github.com:hashicorp:hcl:v2:MPL-2.0':
+    - '*':
+        reason: Project is distributed with unmodified hashicorp/hcl dependency
+        expires: 2022-03-29T09:21:54.881Z
+        created: 2022-01-10T09:21:54.881Z
+patch: {}


### PR DESCRIPTION
### What this does

- Adds a licensing issue to the ignored issues list for this repository.

### Background contex

Until now, licensing issues would not display during tests in the Snyk CLI, when provided with a severity threshold.
This was reported to the Snyk Open Source team, and it appears to be fixed now.
As a result, our pipeline now fails on the Snyk CLI tests, due to an acknowledged licensing issue.

### Notes for the reviewer
- The reason and the expiration date for the ignored were duplicated from the [`.snyk` file for `snyk/snyk-iac-parsers`](https://github.com/snyk/snyk-iac-parsers/blob/main/.snyk), which includes the same issue.

### More information
- [Slack thread](https://snyk.slack.com/archives/C026G6ESL3Y/p1641727594017100)
- [The same licensing issue ignored on the SCM, via the `snyk-iac-group-seceng` org](https://app.snyk.io/org/snyk-iac-group-seceng/project/c329893c-dfdd-4c1c-80a1-6c5a7a95e28b)

