### PR TITLE
chore: Add service catalog to the repository

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,7 +4,7 @@ version: v1.22.1
 ignore:
   'snyk:lic:golang:github.com:hashicorp:hcl:v2:MPL-2.0':
     - '*':
-        reason: Project is distributed with unmodified hashicorp/hcl dependency
-        expires: 2022-03-29T09:21:54.881Z
-        created: 2022-01-10T09:21:54.881Z
+      reason: >-
+        This license is addressed by including acknowledgments in each release
+      created: 2022-01-10T09:21:54.881Z
 patch: {}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+# Documentation: https://www.notion.so/snyk/Entity-Metadata-1e313ca03f954a6680b2b6b7b3d95297
+# Validation Tool: https://github.com/snyk/prodsec-github-bot
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: snyk-iac-rules
+  description: <
+    A Golang SDK that provides commands for writing, debugging, testing, and
+    bundling custom rules for the Snyk CLI
+  labels:
+    snyk.io/businessCriticality: low
+    snyk.io/visibility: public
+    snyk.io/metadata-version: "2021-14-10"
+spec:
+  # Currently type only accepts one of, website, service, library and we've aligned
+  # internally on "service" for CLI tools.
+  # See: https://backstage.io/docs/features/software-catalog/descriptor-format#spectype-required
+  type: service
+  lifecycle: production
+  owner: "@snyk/group-infrastructure-as-code"


### PR DESCRIPTION
Used by the Snyk organization via backstage.io to manage our service catalog. I've had to use `type: service` because there isn't a common `tool` type.

See [documentation](https://www.notion.so/snyk/Entity-Metadata-1e313ca03f954a6680b2b6b7b3d95297) and the internal Slack [thread](https://snyk.slack.com/archives/C02GCNHTUAU/p1641891197010100) for more details on the background.
