### PR TITLE
Run Snyk OS monitor for AppSec group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
 jobs:
   lint_and_format:
     <<: *defaults
-    description: Lint & formatting
+    description: Lint & Formatting
     docker:
       - image: golangci/golangci-lint:v1.42
     steps:
@@ -68,15 +68,34 @@ jobs:
           name: Run Golang tests
           command: go test ./...
   security-oss:
+    parameters:
+      # Allow monitor to be enabled for certain test runs. e.g main/develop
+      monitor-on-build:
+        type: boolean
+        default: false
     docker:
       - image: cimg/go:1.17.2 
     steps:
       - checkout
       - snyk/scan:
           severity-threshold: medium 
-          monitor-on-build: true
+          monitor-on-build: << parameters.monitor-on-build >>
           project: ${CIRCLE_PROJECT_REPONAME}
           organization: snyk-iac-group-seceng
+          additional-arguments: "--project-reference='<< pipeline.git.branch >>'"
+      # duplicate because snyk can only send to one org at a time :(
+      - snyk/scan:
+          monitor-on-build: << parameters.monitor-on-build >>
+          project: snyk/snyk-iac-rules
+          organization: appsec-playground
+          fail-on-issues: false
+          # the token-variable option cannot be used here because the default
+          # environment variable called SNYK_TOKEN provided as part of the
+          # snyk-iac-eng context will always override it so as a workaround
+          # we use this unsupported `--api` flag to take precedence over the
+          # both the `snyk auth` value and the environment.
+          # see: https://github.com/snyk/snyk-orb/issues/65
+          additional-arguments: "--api=$APPSEC_SNYK_TOKEN --project-reference='<< pipeline.git.branch >>'"
   security-code:
     docker:
       - image: cimg/go:1.17.2 
@@ -103,7 +122,7 @@ jobs:
             echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
             source $BASH_ENV
       - run:
-          name: Lint commit message
+          name: Lint Commit Message
           command: echo "$COMMIT_MESSAGE" | npx commitlint
 workflows:
   version: 2
@@ -123,12 +142,30 @@ workflows:
               ignore:
                 - main
                 - develop
+      # OSS Scanning for PR branches
       - security-oss:
-          name: Snyk oss
+          name: Snyk Open Source
           context:
             - snyk-iac-seceng
+          monitor-on-build: false
+          filters:
+            branches:
+              ignore:
+                - main
+                - develop
+      # OSS Scanning for trunk branches (with monitor)
+      - security-oss:
+          name: Snyk Open Source (<< pipeline.git.branch >>)
+          monitor-on-build: true
+          context:
+            - snyk-iac-seceng
+          filters:
+            branches:
+              only:
+                - main
+                - develop
       - security-code:
-          name: Snyk code
+          name: Snyk Code
           context:
             - snyk-iac-seceng
       - regression-test:


### PR DESCRIPTION
### What this does

This extends our circleci configuration to also send the snyk oss monitor results back to the appsec-playground org in snyk. We currently don't support multiple instances of the `--org` flag so for now we're running the command twice, we also need to jump through some hoops to get the authentication to work correctly (see https://github.com/snyk/snyk-orb/issues/65) so we pass the new `APPSEC_SNYK_TOKEN` via the `--api` flag too.

Lastly, we now only send monitor results back to snyk for the main & develop branches so we're not collecting information about the pull requests.

### Notes for the reviewer

We should hopefully see this run automatically as part of this PR run.

