### PR TITLE
feat: add a version flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
     goarch:
     - amd64
     - arm64
+    ldflags:
+    - '-s -w -X github.com/snyk/snyk-iac-rules/cmd.version={{.Version}}'
 
 archives:
   - id: default

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version string = "dev"
+
 // RootCommand is the base CLI command that all subcommands are added to.
 var RootCommand = NewRootCmd()
 
@@ -39,6 +41,7 @@ $ snyk --help
 See our documentation to learn more:
 https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules
 `,
+		Version: version,
 	}
 	rootCommand.CompletionOptions.DisableDefaultCmd = true
 	return rootCommand

--- a/spec/e2e/help_spec.sh
+++ b/spec/e2e/help_spec.sh
@@ -15,7 +15,8 @@ Available Commands:
   test        Execute Rego test cases
 
 Flags:
-  -h, --help   help for snyk-iac-rules
+  -h, --help      help for snyk-iac-rules
+  -v, --version   version for snyk-iac-rules
 
 Use "snyk-iac-rules [command] --help" for more information about a command.'
   End


### PR DESCRIPTION
### What this does



**feat: add a version flag**

So that users can discover what version of snyk-iac-rules they're
running.

This is a supported feature of the cobra CLI framework. Running
`snyk-iac-rules -v` (or `--version`), will print something like:

```
snyk-iac-rules version 1.4.0
```

Since this project already uses goreleaser, this commit configures it to
override the version variable at link time using `go build -ldflags`.



### Notes for the reviewer

I tested this by:

- running `go build` and validating that `./snyk-iac-rules -v` prints the placeholder version "dev", and that neither it nor other snyk-iac-rules subcommands crash
- running `go build -ldflags '-X github.com/snyk/snyk-iac-rules/cmd.version=1.4.0'` and validating that the version flag prints the injected version string
- running `goreleaser build --snapshot` and validating that the build binary (for darwin_amd64) prints a non-default version when the version flag is called
   - We won't 100% know for sure until we cut a release, but I'm reasonably confident the goreleaser github action that runs on main should "just work" with this change, passing in it's `.Version` template variable according to its own tag-based logic.
