### PR TITLE
fix: NPM package version

### DIFF
--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -24,6 +24,9 @@ if [ -z "$TAG" ]; then
     exit 1
 fi
 
+VERSION_FOR_OUTPUT=${TAG/v/}
+GO_LDFLAGS="-s -w -X github.com/snyk/snyk-iac-rules/cmd.version=$VERSION_FOR_OUTPUT"
+
 cd $(dirname $0)/..
 
 rm -rf dist
@@ -34,11 +37,13 @@ echo "Updating NPM package version to ${TAG}"
 
 mkdir -p dist/
 
+# TODO use the goreleaser-built binaries from the GitHub relase instead of
+# building from scratch
 for GOOS in linux darwin; do
-    GOOS=$GOOS GOARCH=amd64 go build -a -o dist/snyk-iac-rules-$GOOS-x64 .
-    GOOS=$GOOS GOARCH=arm64 go build -a -o dist/snyk-iac-rules-$GOOS-arm64 .
+    GOOS=$GOOS GOARCH=amd64 go build -a -o dist/snyk-iac-rules-$GOOS-x64 -ldflags "$GO_LDFLAGS" .
+    GOOS=$GOOS GOARCH=arm64 go build -a -o dist/snyk-iac-rules-$GOOS-arm64 -ldflags "$GO_LDFLAGS" .
 done
-GOOS=windows GOARCH=amd64 go build -a -o dist/snyk-iac-rules-win.exe .
+GOOS=windows GOARCH=amd64 go build -a -o dist/snyk-iac-rules-win.exe -ldflags "$GO_LDFLAGS" .
 
 cp packaging/npm/passthrough.js dist/snyk-iac-rules
 cp README.md dist/README.md


### PR DESCRIPTION
The NPM package does not (currently) use the goreleaser-built version
from the GitHub release, and so was not picking up the link-time
injected version string.

This commit fixes that by copying the ldflags logic from goreleaser.

---

I tested this by running the script `./scripts/release-npm.sh --tag=v1.2.3 && ./dist/snyk-iac-rules-darwin-x64 -v` prints `snyk-iac-rules version 1.2.3`.

If approved, are you happy for me to make a release to test this out while the context is fresh?