### PR TITLE
feat: validate severity level [CFG-1865]

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -67,7 +67,7 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 func newBuildCommandParams() *internal.BuildCommandParams {
 	return &internal.BuildCommandParams{
 		Entrypoint:   util.NewRepeatedStringFlag("rules/deny"),
-		Target:       util.NewEnumFlag(internal.TargetWasm, []string{internal.TargetRego, internal.TargetWasm}),
+		Target:       util.NewEnumFlag(util.TargetWasm, []string{util.TargetRego, util.TargetWasm}),
 		Capabilities: util.NewCapabilitiesFlag(),
 	}
 }

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -56,7 +56,7 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 
 func newParseCommandParams() *internal.ParseCommandParams {
 	return &internal.ParseCommandParams{
-		Format: util.NewEnumFlag(internal.HCL2, []string{internal.HCL2, internal.YAML, internal.TERRAFORM_PLAN}),
+		Format: util.NewEnumFlag(util.HCL2, []string{util.HCL2, util.YAML, util.TERRAFORM_PLAN}),
 	}
 }
 

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -88,8 +88,8 @@ $ snyk-iac-rules test --help
 
 func newTemplateCommandParams() *internal.TemplateCommandParams {
 	return &internal.TemplateCommandParams{
-		RuleSeverity: util.NewEnumFlag(internal.LOW, []string{internal.LOW, internal.MEDIUM, internal.HIGH, internal.CRITICAL}),
-		RuleFormat:   util.NewEnumFlag("", []string{internal.HCL2, internal.JSON, internal.YAML, internal.TERRAFORM_PLAN}),
+		RuleSeverity: util.NewEnumFlag(util.LOW, util.ValidSeverityLevels),
+		RuleFormat:   util.NewEnumFlag("", []string{util.HCL2, util.JSON, util.YAML, util.TERRAFORM_PLAN}),
 	}
 }
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -70,7 +70,7 @@ https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-s
 
 func newTestCommandParams() *internal.TestCommandParams {
 	return &internal.TestCommandParams{
-		Explain: util.NewEnumFlag(internal.ExplainModeFails, []string{internal.ExplainModeFails, internal.ExplainModeFull, internal.ExplainModeNotes}),
+		Explain: util.NewEnumFlag(util.ExplainModeFails, []string{util.ExplainModeFails, util.ExplainModeFull, util.ExplainModeNotes}),
 	}
 }
 

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -11,13 +11,6 @@ import (
 	"github.com/snyk/snyk-iac-rules/util"
 )
 
-const (
-	JSON           = "json"
-	HCL2           = "hcl2"
-	YAML           = "yaml"
-	TERRAFORM_PLAN = "tf-plan"
-)
-
 var readFile = ioutil.ReadFile
 var parseYAML = parsers.ParseYAML
 var parseHCL2 = parsers.ParseHCL2
@@ -37,11 +30,11 @@ func RunParse(args []string, params *ParseCommandParams) error {
 
 	var parsedInput interface{}
 	switch params.Format.String() {
-	case YAML:
+	case util.YAML:
 		if err := parseYAML(content, &parsedInput); err != nil {
 			return err
 		}
-	case TERRAFORM_PLAN:
+	case util.TERRAFORM_PLAN:
 		if err := parseTerraformPlan(content, &parsedInput); err != nil {
 			return err
 		}

--- a/internal/parse_test.go
+++ b/internal/parse_test.go
@@ -13,7 +13,7 @@ import (
 
 func mockParseParams() *ParseCommandParams {
 	return &ParseCommandParams{
-		Format: util.NewEnumFlag(HCL2, []string{HCL2, YAML, TERRAFORM_PLAN}),
+		Format: util.NewEnumFlag(util.HCL2, []string{util.HCL2, util.YAML, util.TERRAFORM_PLAN}),
 	}
 }
 
@@ -48,7 +48,7 @@ func TestParse(t *testing.T) {
 		}
 
 		parseParams := mockParseParams()
-		err = parseParams.Format.Set(YAML)
+		err = parseParams.Format.Set(util.YAML)
 		assert.Nil(t, err)
 
 		err = RunParse([]string{"test"}, parseParams)
@@ -86,7 +86,7 @@ func TestParse(t *testing.T) {
 		}
 
 		parseParams := mockParseParams()
-		err = parseParams.Format.Set(HCL2)
+		err = parseParams.Format.Set(util.HCL2)
 		assert.Nil(t, err)
 
 		err = RunParse([]string{"test"}, parseParams)
@@ -124,7 +124,7 @@ func TestParse(t *testing.T) {
 		}
 
 		parseParams := mockParseParams()
-		err = parseParams.Format.Set(TERRAFORM_PLAN)
+		err = parseParams.Format.Set(util.TERRAFORM_PLAN)
 		assert.Nil(t, err)
 
 		err = RunParse([]string{"test"}, parseParams)

--- a/internal/push.go
+++ b/internal/push.go
@@ -14,6 +14,8 @@ import (
 
 	"oras.land/oras-go/pkg/content"
 	"oras.land/oras-go/pkg/oras"
+
+	util "github.com/snyk/snyk-iac-rules/util"
 )
 
 var push = oras.Push
@@ -21,11 +23,6 @@ var push = oras.Push
 type PushCommandParams struct {
 	BundleRegistry string
 }
-
-const (
-	customConfigMediaType       = "application/vnd.oci.image.config.v1+json"
-	customTarballLayerMediaType = "application/vnd.oci.image.layer.v1.tar+gzip"
-)
 
 const configContents = `{
 	"mediaType": "application/vnd.oci.image.config.v1+json"
@@ -88,11 +85,11 @@ var loadBundle = func(ctx context.Context, memoryStore *content.Memorystore, pat
 		return ocispec.Descriptor{}, fmt.Errorf("Failed to read bundle contents: " + err.Error())
 	}
 
-	return memoryStore.Add(path, customTarballLayerMediaType, bundleContents), nil
+	return memoryStore.Add(path, util.CustomTarballLayerMediaType, bundleContents), nil
 }
 
 var loadConfig = func(memoryStore *content.Memorystore) ocispec.Descriptor {
-	descriptor := memoryStore.Add("config.json", customConfigMediaType, []byte(configContents))
+	descriptor := memoryStore.Add("config.json", util.CustomConfigMediaType, []byte(configContents))
 	descriptor.Annotations = nil
 	return descriptor
 }

--- a/internal/template.go
+++ b/internal/template.go
@@ -10,13 +10,6 @@ import (
 	"github.com/snyk/snyk-iac-rules/util"
 )
 
-const (
-	LOW      = "low"
-	MEDIUM   = "medium"
-	HIGH     = "high"
-	CRITICAL = "critical"
-)
-
 type TemplateCommandParams struct {
 	RuleID       string
 	RuleTitle    string
@@ -46,13 +39,13 @@ func RunTemplate(args []string, params *TemplateCommandParams) error {
 
 func getTemplateByFormat(format string) (string, string, error) {
 	switch format {
-	case JSON:
+	case util.JSON:
 		return "main_test_json", ".json", nil
-	case YAML:
+	case util.YAML:
 		return "main_test_yaml", ".yaml", nil
-	case HCL2:
+	case util.HCL2:
 		return "main_test_hcl2", ".tf", nil
-	case TERRAFORM_PLAN:
+	case util.TERRAFORM_PLAN:
 		return "main_test_tfplan", ".json.tfplan", nil
 	default:
 		// should never get to here

--- a/internal/template_test.go
+++ b/internal/template_test.go
@@ -14,7 +14,7 @@ func mockTemplateParams(format string) *TemplateCommandParams {
 	return &TemplateCommandParams{
 		RuleID:       "Test Rule ID",
 		RuleTitle:    "Test Rule Title",
-		RuleSeverity: util.NewEnumFlag(LOW, []string{LOW, MEDIUM, HIGH, CRITICAL}),
+		RuleSeverity: util.NewEnumFlag(util.LOW, []string{util.LOW, util.MEDIUM, util.HIGH, util.CRITICAL}),
 		RuleFormat:   util.NewEnumFlag(format, []string{format}),
 	}
 }
@@ -54,16 +54,16 @@ type file struct {
 func createTestFiles(format string) []file {
 	var test, extension string
 	switch format {
-	case HCL2:
+	case util.HCL2:
 		test = "main_test_hcl2"
 		extension = ".tf"
-	case JSON:
+	case util.JSON:
 		test = "main_test_json"
 		extension = ".json"
-	case YAML:
+	case util.YAML:
 		test = "main_test_yaml"
 		extension = ".yaml"
-	case TERRAFORM_PLAN:
+	case util.TERRAFORM_PLAN:
 		test = "main_test_tfplan"
 		extension = ".json.tfplan"
 	default:
@@ -113,10 +113,10 @@ type formatTest struct {
 }
 
 var tests = []formatTest{
-	{format: HCL2},
-	{format: JSON},
-	{format: YAML},
-	{format: TERRAFORM_PLAN},
+	{format: util.HCL2},
+	{format: util.JSON},
+	{format: util.YAML},
+	{format: util.TERRAFORM_PLAN},
 }
 
 func TestTemplateInEmptyDirectory(t *testing.T) {
@@ -154,7 +154,7 @@ func TestTemplateInEmptyDirectory(t *testing.T) {
 			assert.Equal(t, files[filesIndex].template, template)
 			assert.Equal(t, "Test Rule ID", templating.RuleID)
 			assert.Equal(t, "Test Rule Title", templating.RuleTitle)
-			assert.Equal(t, LOW, templating.RuleSeverity)
+			assert.Equal(t, util.LOW, templating.RuleSeverity)
 
 			filesIndex++
 			return nil
@@ -214,7 +214,7 @@ func TestTemplateInDirectoryWithLibWithTfPlan(t *testing.T) {
 			assert.Equal(t, files[filesIndex].template, template)
 			assert.Equal(t, "Test Rule ID", templating.RuleID)
 			assert.Equal(t, "Test Rule Title", templating.RuleTitle)
-			assert.Equal(t, LOW, templating.RuleSeverity)
+			assert.Equal(t, util.LOW, templating.RuleSeverity)
 
 			filesIndex++
 			return nil
@@ -281,7 +281,7 @@ func TestTemplateInDirectoryWithLibWithoutTfPlan(t *testing.T) {
 			assert.Equal(t, files[filesIndex].template, template)
 			assert.Equal(t, "Test Rule ID", templating.RuleID)
 			assert.Equal(t, "Test Rule Title", templating.RuleTitle)
-			assert.Equal(t, LOW, templating.RuleSeverity)
+			assert.Equal(t, util.LOW, templating.RuleSeverity)
 
 			// if creating the tfplan testing file then change its order
 			if strings.Contains(workingDirectory, "/lib/testing") {

--- a/internal/test.go
+++ b/internal/test.go
@@ -17,12 +17,6 @@ import (
 
 // Most of the logic was taken from https://github.com/open-policy-agent/opa/blob/v0.31.0/cmd/test.go
 
-const (
-	ExplainModeFull  = "full"
-	ExplainModeNotes = "notes"
-	ExplainModeFails = "fails"
-)
-
 type TestCommandParams struct {
 	Verbose  bool
 	Explain  util.EnumFlag
@@ -112,7 +106,7 @@ func filterTrace(trace []*topdown.Event, params *TestCommandParams) []*topdown.E
 	ops := map[topdown.Op]struct{}{}
 	mode := params.Explain.String()
 
-	if mode == ExplainModeFull {
+	if mode == util.ExplainModeFull {
 		// Don't bother filtering anything
 		return trace
 	}
@@ -122,10 +116,10 @@ func filterTrace(trace []*topdown.Event, params *TestCommandParams) []*topdown.E
 	// default to show both notes and fail events
 	showDefault := !params.Explain.IsSet() && params.Verbose
 
-	if mode == ExplainModeNotes || showDefault {
+	if mode == util.ExplainModeNotes || showDefault {
 		ops[topdown.NoteOp] = struct{}{}
 	}
-	if mode == ExplainModeFails || showDefault {
+	if mode == util.ExplainModeFails || showDefault {
 		ops[topdown.FailOp] = struct{}{}
 	}
 

--- a/internal/test_test.go
+++ b/internal/test_test.go
@@ -18,7 +18,7 @@ import (
 func mockTestParams() *TestCommandParams {
 	return &TestCommandParams{
 		Verbose:  false,
-		Explain:  util.NewEnumFlag(ExplainModeFails, []string{ExplainModeFails, ExplainModeFull, ExplainModeNotes}),
+		Explain:  util.NewEnumFlag(util.ExplainModeFails, []string{util.ExplainModeFails, util.ExplainModeFull, util.ExplainModeNotes}),
 		Timeout:  5 * time.Second,
 		Ignore:   []string{},
 		RunRegex: "",
@@ -64,7 +64,7 @@ func TestFilterTraceVerbose(t *testing.T) {
 
 func TestFilterTraceExplainFails(t *testing.T) {
 	testParams := mockTestParams()
-	err := testParams.Explain.Set(ExplainModeFails)
+	err := testParams.Explain.Set(util.ExplainModeFails)
 	assert.Nil(t, err)
 
 	expected := `Enter data.testing.test_p = _
@@ -83,7 +83,7 @@ func TestFilterTraceExplainFails(t *testing.T) {
 
 func TestFilterTraceExplainNotes(t *testing.T) {
 	testParams := mockTestParams()
-	err := testParams.Explain.Set(ExplainModeNotes)
+	err := testParams.Explain.Set(util.ExplainModeNotes)
 	assert.Nil(t, err)
 
 	expected := `Enter data.testing.test_p = _
@@ -100,7 +100,7 @@ func TestFilterTraceExplainNotes(t *testing.T) {
 
 func TestFilterTraceExplainFull(t *testing.T) {
 	testParams := mockTestParams()
-	err := testParams.Explain.Set(ExplainModeFull)
+	err := testParams.Explain.Set(util.ExplainModeFull)
 	assert.Nil(t, err)
 
 	expected := `Enter data.testing.test_p = _

--- a/util/constants.go
+++ b/util/constants.go
@@ -1,0 +1,33 @@
+package util
+
+const (
+	TargetRego = "rego"
+	TargetWasm = "wasm"
+)
+
+const (
+	JSON           = "json"
+	HCL2           = "hcl2"
+	YAML           = "yaml"
+	TERRAFORM_PLAN = "tf-plan"
+)
+
+const (
+	LOW      = "low"
+	MEDIUM   = "medium"
+	HIGH     = "high"
+	CRITICAL = "critical"
+)
+
+var ValidSeverityLevels = []string{LOW, MEDIUM, HIGH, CRITICAL}
+
+const (
+	CustomConfigMediaType       = "application/vnd.oci.image.config.v1+json"
+	CustomTarballLayerMediaType = "application/vnd.oci.image.layer.v1.tar+gzip"
+)
+
+const (
+	ExplainModeFull  = "full"
+	ExplainModeNotes = "notes"
+	ExplainModeFails = "fails"
+)

--- a/util/inspect_test.go
+++ b/util/inspect_test.go
@@ -37,6 +37,26 @@ func TestRetrieveRulesWithNoRules(t *testing.T) {
 	})
 }
 
+func TestRetrieveRulesWithRulesWithPublicIdAndSeverityLevel(t *testing.T) {
+	files := map[string]string{
+		"test.rego": `
+			package test
+			msg = {
+				"publicId": "1",
+				"severity": "low"
+			}
+		`,
+	}
+
+	test.WithTempFS(files, func(root string) {
+		rules, err := RetrieveRules([]string{root})
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(rules))
+		assert.Equal(t, "1", rules[0].PublicId)
+		assert.Equal(t, "low", rules[0].SeverityLevel)
+	})
+}
+
 func TestRetrieveRulesWithRulesWithoutPublicId(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `


### PR DESCRIPTION
### What this does

This PR enhances the existing validation in the SDK to flag up when someone tries to bundle rules that have invalid severity levels.

### Notes for the reviewer
1. `go build  -o snyk-iac-rules .`
2. Run `./snyk-iac-rules build ./fixtures/custom-rules` to confirm it still works
3. Modify one of the severities to something like `"invalid"`
4. Run `./snyk-iac-rules build ./fixtures/custom-rules` again to see the error
![Screenshot 2022-05-25 at 13 30 51](https://user-images.githubusercontent.com/81559517/170262467-504096ce-dc31-4ab6-8a97-bc91dc64a898.png)


### More information

- [Jira ticket CFG-1865](https://snyksec.atlassian.net/browse/CFG-1865)

