### PR TITLE
Add ignore for the vuln that comes from github.com/open-policy-agent/…

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,4 +7,8 @@ ignore:
       reason: >-
         This license is addressed by including acknowledgments in each release
       created: 2022-01-10T09:21:54.881Z
+  'SNYK-GOLANG-GITHUBCOMOPENPOLICYAGENTOPAAST-2840626':
+    - '*':
+      reason: 'The fix available is a breaking change and team is busy working on other tasks'
+      expires '2022-06-30T00:00:00.000Z':
 patch: {}


### PR DESCRIPTION
### What this does

.Snyk ignore modification to ignore a vuln temporarily until the team changes functionality.
The expiration is set to 2022-06-30T00:00:00.000.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Jira ticket CC-0000](https://snyksec.atlassian.net/browse/CC-0000)
- [Link to documentation](https://github.com/Snyk/registry/wiki/)

