### PR TITLE
chore: disable case sensitivity in commit lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           name: Define environment variable with lastest commit's message
           command: |
             npm install --save-dev @commitlint/config-conventional @commitlint/cli
-            echo "module.exports = {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
+            echo "module.exports = {extends: ['@commitlint/config-conventional'], rules: {'subject-case': [0, 'always']}};" > commitlint.config.js
             echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
             source $BASH_ENV
       - run:

--- a/internal/push.go
+++ b/internal/push.go
@@ -48,11 +48,11 @@ func pushBundle(ctx context.Context, memoryStore *content.Memorystore, repositor
 	}
 	config := loadConfig(memoryStore)
 
-	desriptors := []ocispec.Descriptor{
+	descriptors := []ocispec.Descriptor{
 		bundle,
 	}
 	pushOpts := configurePushOpts(config)
-	_, err = push(ctx, resolver, repository, memoryStore, desriptors, pushOpts...)
+	_, err = push(ctx, resolver, repository, memoryStore, descriptors, pushOpts...)
 	if err != nil {
 		return fmt.Errorf("Failed to push bundle to container registry: " + err.Error())
 	}


### PR DESCRIPTION
### What this does

Disables the subject case rule looking for case sensitive chars etc in the commit message.

Examples runs in this branch against different commit messages https://app.circleci.com/pipelines/github/snyk/snyk-iac-rules?branch=chore%2Fdisable-subject-case-lint&filter=all