### PR TITLE
chore: fix release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,11 +181,10 @@ workflows:
           name: Regression Test
           requires:
             - Lint & formatting
+          <<: *only_feature_branch
       - approve-release:
           name: Approve Release
           type: approval
-          requires:
-            - Regression Test
           <<: *only_release_branch
       - release:
           name: Release


### PR DESCRIPTION
### What this does
In https://github.com/snyk/snyk-iac-rules/pull/168 I accidentally made it so the release job never runs because it was dependant on a previous job that only runs in the feature branch, whereas the release job only runs in the release branch.

The tests already run on PRs so hopefully it's fine to skip the tests before a release.