### PR TITLE
chore: update release process [CFG-1049]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,16 @@ jobs:
       - run:
           name: Lint commit message
           command: echo "$COMMIT_MESSAGE" | npx commitlint
+  tag:
+    <<: *defaults
+    docker:
+      - image: cimg/go:1.18.2
+    steps:
+      - checkout
+      - add_ssh_key
+      - run:
+          name: Push new tag to GitHub
+          command: ./scripts/tag.sh
   release:
     <<: *defaults
     docker:
@@ -134,9 +144,6 @@ jobs:
       - run:
           name: Login to Snyk's Docker Hub
           command: echo $DOCKER_PASSWORD  | docker login -u $DOCKER_USERNAME --password-stdin
-      - run:
-          name: Push new tag to GitHub
-          command: ./scripts/tag.sh
       - run:
           name: Release binaries to GitHub
           command: ./scripts/release-github.sh
@@ -182,9 +189,14 @@ workflows:
           requires:
             - Lint & formatting
           <<: *only_feature_branch
+      - tag:
+          name: Tag
+          <<: *only_release_branch
       - approve-release:
           name: Approve Release
           type: approval
+          requires:
+            - Tag
           <<: *only_release_branch
       - release:
           name: Release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,14 @@
 project_name: snyk-iac-rules
 
+before:
+  # run this here to avoid "git is currently in a dirty state" error
+  hooks:
+    - go mod tidy
+    - go install github.com/google/go-licenses@latest
+    - go-licenses save . --save_path=./acknowledgements
+    - tar -cvf ./acknowledgements.tar.gz -C ./acknowledgements .
+    - rm -rf ./acknowledgements
+
 builds:
   - main: ./main.go
     env:

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -6,15 +6,6 @@ if ! which goreleaser >/dev/null ; then
     go install github.com/goreleaser/goreleaser@v1.9.2
 fi
 
-if ! which go-licenses >/dev/null ; then
-    go install github.com/google/go-licenses@latest
-fi
-
-# Generate acknowledgements
-go-licenses save . --save_path=./acknowledgements
-tar -cvf ./acknowledgements.tar.gz -C ./acknowledgements .
-rm -rf ./acknowledgements
-
 # Check configuration
 goreleaser check
 

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -14,6 +14,12 @@ fi
 
 TAG=$(svu)
 
+# TODO: remove this when we rename develop branch to main
+# temporarily set the tag to a new one so we trigger release from develop
+if [ $TAG == "v1.0.0" ]; then
+  TAG="v1.5.3"
+fi
+
 if [ $(git tag -l "TAG") ]; then
     echo "Tag already exists!"
     exit 0


### PR DESCRIPTION
### What this does

This PR splits up the new release process into multiple steps so we only trigger the approval process if a new tag was pushed, and it makes sure to fix the release process for `develop`.

### Notes for the reviewer

As we can see from the latest run in `develop`, we cannot trigger a release because we haven't got the latest tags for `develop`: https://app.circleci.com/pipelines/github/snyk/snyk-iac-rules/1157/workflows/78e08ab2-05a9-461b-8343-97817474477e/jobs/3225
The release process, which included creating tags, has been running on `main` so all the tags are recognised for that branch.

We remediate that by adding a temporary new tag `v1.5.3`, since the latest existing tag is `v1.5.2`: 
https://github.com/snyk/snyk-iac-rules/releases
This step will be removed in a follow-up PR.

Proof of test run in this branch: https://app.circleci.com/pipelines/github/snyk/snyk-iac-rules/1161/workflows/8d60a1e1-c596-4ef3-9315-9297170b03fc
![Screenshot 2022-06-21 at 09 29 21](https://user-images.githubusercontent.com/81559517/174754101-cfe12f88-9be1-4331-a710-a0b7de68e18b.png)
- it's successful up until it tries to create a release because git was in a dirty state but this is also fixed in this PR


### More information

- [Jira ticket CFG-1049](https://snyksec.atlassian.net/browse/CFG-1049)

