### PR TITLE
chore: update release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
           name: Release binaries to NPM
           command: |
             # Install for envsubst
-            sudo apt install gettext-base
+            sudo apt-get update && sudo apt-get install gettext-base
             ./scripts/release-npm.sh --tag=$TAG
             
             cd dist/


### PR DESCRIPTION
I got the command for installing `gettest-base` wrong. We need this to use `envsubst`, and this page says we should use `apt-get` not `apt` for Ubuntu: https://command-not-found.com/envsubst

I'm still not sure it will work though based on https://itsfoss.com/apt-vs-apt-get-difference/, which says `apt` is just a more user friendly version of `apt-get`

So I also add an `apt-get update` like https://askubuntu.com/questions/14685/what-does-package-package-has-no-installation-candidate-mean says

Here is the failure: https://app.circleci.com/pipelines/github/snyk/snyk-iac-rules/1166/workflows/62441dea-f31a-4f1e-9709-68d