### PR TITLE
chore: remove references to develop [CFG-1049]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,19 +4,18 @@ orbs:
   snyk: snyk/snyk@1.1.1
   node: circleci/node@5.0.2
 
-# TODO: to change develop to main once we delete it
 defaults: &defaults
   working_directory: ~/snyk-iac-rules
 only_feature_branch: &only_feature_branch
   filters:
     branches:
       ignore:
-        - develop
+        - main
 only_release_branch: &only_release_branch
   filters:
     branches:
       only:
-        - develop
+        - main
 
 commands:
   install_shellspec:
@@ -166,8 +165,6 @@ jobs:
           command: |
             # Install for envsubst
             sudo apt-get update && sudo apt-get install gettext-base
-
-            cat env-vars
 
             cat env-vars >> $BASH_ENV
             ./scripts/release-npm.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - '**'        # matches every branch
-      - '!develop'     # excludes main # TODO: to change develop to main once we delete it
+      - '!main'     # excludes main
 
 jobs:
   shellspec_test:

--- a/.github/workflows/registries.yml
+++ b/.github/workflows/registries.yml
@@ -3,7 +3,7 @@ name: Registries Tests
 on:
   push:
     branches:
-      - 'develop' # TODO: to change develop to main once we delete it
+      - 'main'
 
 jobs:
   dockerhub:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -182,7 +182,7 @@ Make sure to have the aws CLI installed locally if you're running the Elastic te
 
 Finally, run `shellspec "spec/registries"` to verify if the generated bundle from the SDK is valid for the Snyk CLI.
 
-These tests run as part of the CI/CD for the `develop` branch on Linux only.
+These tests run as part of the CI/CD for the `main` branch on Linux only.
 
 #### Unit tests
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `snyk-iac-rules` SDK
 ---
 
-[![CircleCI](https://circleci.com/gh/snyk/snyk-iac-rules/tree/develop.svg?style=svg&circle-token=5597b9f0189554f754f38400cbe9d8f8b334c72a)](https://circleci.com/gh/snyk/snyk-iac-rules/tree/develop) 
+[![CircleCI](https://circleci.com/gh/snyk/snyk-iac-rules/tree/main.svg?style=svg&circle-token=5597b9f0189554f754f38400cbe9d8f8b334c72a)](https://circleci.com/gh/snyk/snyk-iac-rules/tree/main) 
 [![Shellspec Tests](https://github.com/snyk/snyk-iac-rules/actions/workflows/main.yml/badge.svg)](https://github.com/snyk/snyk-iac-rules/actions/workflows/main.yml)
 [![Contract Tests](https://github.com/snyk/snyk-iac-rules/actions/workflows/contract.yml/badge.svg)](https://github.com/snyk/snyk-iac-rules/actions/workflows/contract.yml)
 [![Registries Tests](https://github.com/snyk/snyk-iac-rules/actions/workflows/registries.yml/badge.svg)](https://github.com/snyk/snyk-iac-rules/actions/workflows/registries.yml)
@@ -18,7 +18,7 @@
 The SDK is a tool for writing, debugging, testing, and bundling custom rules for [Snyk Infrastructure as Code](https://snyk.io/product/infrastructure-as-code-security/). See our [Custom Rules documentation](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules) to learn more.
 
 <!---
-This should be generated automatically from the UML code. We need to specify the branch name though, and this can not happen while we are in develop/main. We need to get the branch name first if we continue using two branches. For now, we can use the rendered image instead.
+This should be generated automatically from the UML code. We need to specify the branch name though, and this can not happen while we are in main. We need to get the branch name first if we continue using two branches. For now, we can use the rendered image instead.
 
 ![system overview](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.github.com/snyk/snyk-iac-rules/main/assets/overview-activity-swimlanes.puml)
 -->

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,5 +39,5 @@ $ snyk-iac-rules help
 ## CI/CD
 As part of every PR from a feature branch to the release branch, we run both CircleCI as well as the `E2E Tests` and `Contract Tests` GitHub Actions, which run our shellspec tests in Windows, Linux, and MacOS. The CircleCI pipeline runs the `golangci-lint` linter, `gofmt`, and `go mod tidy`, and then it runs `shellspec` end-to-end tests and the Golang unit tests on a Linux distribution.
 
-Once the PR is merged into `develop`, the CircleCI release process described in this document runs.
+Once the PR is merged into `main`, the CircleCI release process described in this document runs.
 

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -14,12 +14,6 @@ fi
 
 TAG=$(svu)
 
-# TODO: remove this when we rename develop branch to main
-# temporarily set the tag to a new one so we trigger release from develop
-if [ $TAG == "v1.0.0" ]; then
-  TAG="v1.5.3"
-fi
-
 if [ $(git tag -l "TAG") ]; then
     echo "Tag already exists!"
     exit 0


### PR DESCRIPTION
This is the last change required to remove the `develop` branch. I've renamed `develop` to `main` and the old `main` branch to `main-backup`, just in case and because old GitHub releases are linked to commits on this branch.

https://snyksec.atlassian.net/browse/CFG-1049