### PR TITLE
chore: use goreleaser binaries in npm [CFG-1786]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
     <<: *defaults
     description: Lint & formatting
     docker:
-      - image: golangci/golangci-lint:v1.42
+      - image: golangci/golangci-lint:v1.46
     steps:
       - checkout
       # Logs the version in our build logs, for posterity
@@ -64,7 +64,7 @@ jobs:
   regression-test:
     <<: *defaults
     docker:
-      - image: cimg/go:1.17
+      - image: cimg/go:1.18.2
     steps:
       - checkout
       - install_shellspec
@@ -83,7 +83,7 @@ jobs:
           command: go test ./...
   security-oss:
     docker:
-      - image: cimg/go:1.17.2 
+      - image: cimg/go:1.18.2
     steps:
       - checkout
       - snyk/scan:
@@ -93,7 +93,7 @@ jobs:
           organization: snyk-iac-group-seceng
   security-code:
     docker:
-      - image: cimg/go:1.17.2 
+      - image: cimg/go:1.18.2
     steps:
       - checkout
       - snyk/scan:

--- a/.github/actions/setup_shellspec/action.yml
+++ b/.github/actions/setup_shellspec/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Build custom rules SDK
       shell: bash

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: Build Golang CLI
         run: go build -o snyk-iac-rules .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: Build Golang CLI
         run: go build -o snyk-iac-rules .
@@ -94,7 +94,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: Install NPM package - non-Windows
         if: ${{ matrix.os != 'windows' }}
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Build binaries
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ changelog:
     - '^Merge pull request'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  name_template: "{{ .Version }}"
 
 release:
   # If set to true, will not auto-publish the release.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ### Go
 
-This repo is written in the [Go](https://golang.org) programming language, which can be installed from their [installation page](https://golang.org/doc/install). The version it was developed with was v1.17, which is the minimum required version for this SDK.
+This repo is written in the [Go](https://golang.org) programming language, which can be installed from their [installation page](https://golang.org/doc/install). The version it was developed with was v1.18, which is the minimum required version for this SDK.
 
 ### Shellspec
 The SDK developed in this repo is tested by [shellspec](https://github.com/shellspec/shellspec), which can be installed as documented in [their README](https://github.com/shellspec/shellspec#installation).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/snyk-iac-rules
 
-go 1.17
+go 1.18
 
 require (
 	github.com/open-policy-agent/opa v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -116,7 +116,6 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
@@ -610,7 +609,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=

--- a/packaging/npm/passthrough.js
+++ b/packaging/npm/passthrough.js
@@ -3,16 +3,34 @@
 var path = require('path');
 
 // os and arch restrictions are handled by the package.json
-var os = process.platform;
-var arch = process.arch;
+var os = '';
+switch (process.platform) {
+  case 'darwin':
+    os = 'darwin';
+    break;
+  case 'win32':
+    os = 'windows';
+    break;
+  default:
+    os = 'linux';
+};
+
+var arch = ''
+switch (process.arch) {
+  case 'arm' :
+    arch = 'arm64';
+    break;
+  case 'x64':
+    arch = 'amd64_v1';
+    break;
+  default:
+    throw new Error(`Architecture not supported: ${process.arch}`)
+}
 
 // Select the right binary for this platform, then exec it with the original
 // arguments. This is a true exec(3), which will take over the pid, env, and
 // file descriptors.
-var iacCustomRulesPath = path.join(__dirname, './snyk-iac-rules-' + os + '-' + arch);
-if (os === 'win32') {
-  iacCustomRulesPath = path.join(__dirname, './snyk-iac-rules-win.exe');
-}
+var iacCustomRulesPath = path.join(__dirname, './snyk-iac-rules' + '_' + os + '_' + arch, 'snyk-iac-rules');
 
 try {
   var spawn = require('child_process').spawn;


### PR DESCRIPTION
### What this does

This PR changes the NPM release process to use the binaries generated by GoReleaser instead of building its own. 
It also updates the Go version, which I tested by running the SDK end-to-end (the `shellspec` tests in the repo also verify the same steps).

### Notes for the reviewer

There are `npm install` tests for Ubuntu, MacOS, and Windows that verify if the NPM package can be installed locally from the `dist/` folder and it runs correctly by calling `snyk-iac-rules` and returning the help output.

### More information

- [Jira ticket CFG-1786](https://snyksec.atlassian.net/browse/CFG-1786)

