### PR TITLE
fix: ignore an unfixed open-source vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,10 +1,14 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.1
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'snyk:lic:golang:github.com:hashicorp:hcl:v2:MPL-2.0':
     - '*':
-      reason: >-
-        This license is addressed by including acknowledgments in each release
-      created: 2022-01-10T09:21:54.881Z
+        reason: This license is addressed by including acknowledgments in each release
+        created: 2022-01-10T09:21:54.881Z
+  SNYK-GOLANG-GITHUBCOMOPENPOLICYAGENTOPAAST-2938528:
+    - '*':
+        reason: There is no fixed version.
+        expires: 2022-08-03T08:14:03.074Z
+        created: 2022-07-04T08:14:03.080Z
 patch: {}


### PR DESCRIPTION
For 1 month, in case a fix is released.