### PR TITLE
fix: print error when unsafe rego

### DIFF
--- a/internal/test.go
+++ b/internal/test.go
@@ -80,6 +80,7 @@ func RunTest(args []string, params *TestCommandParams) error {
 func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runner, reporter tester.Reporter, params *TestCommandParams) error {
 	ch, err := runner.RunTests(ctx, txn)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		return err
 	}
 


### PR DESCRIPTION
### What this does

There was an edge case where we weren't returning errors, when the rego was using undefined variables. Now it prints the below:
![Screenshot 2022-09-16 at 14 58 51](https://user-images.githubusercontent.com/81559517/190656618-52bcbc09-750a-41b7-a90b-e8c47768b2d1.png)


And for the correct case it still works as expected:
![Screenshot 2022-09-16 at 14 58 53](https://user-images.githubusercontent.com/81559517/190656609-a5d77fe4-73e4-4add-a247-c1f5359fa895.png)


### More information
Flagged in thread: https://snyk.slack.com/archives/CRV0PMFDH/p1663267005693869
