### PR TITLE
Update codeownership back to the IaC group.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/iac-language-support
+* @snyk/group-infrastructure-as-code


### PR DESCRIPTION
The snyk-iac-language-support github handle was not supposed to be used in code ownership and it doesn't really exist as a team/concept anymore. So I'm reverting it back to the iac group ownership.
