### PR TITLE
chore: disable snyk monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - checkout
       - snyk/scan:
           severity-threshold: medium 
-          monitor-on-build: true
+          monitor-on-build: false
           project: ${CIRCLE_PROJECT_REPONAME}
           organization: cloud-cloud
   security-code:


### PR DESCRIPTION
Disabling monitor to avoid duplication of vulns in Snyk UI.

[Slack Thread](https://snyk.slack.com/archives/C04N7LW0D5H/p1679052263654529)