### PR TITLE
fix: replace context used for cicd checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,14 +187,14 @@ workflows:
       - security-oss:
           name: Snyk oss
           context:
-            - snyk-iac-seceng
+            - snyk-cloud-dev-ex
           requires:
             - Lint & formatting
           <<: *only_feature_branch
       - security-code:
           name: Snyk code
           context:
-            - snyk-iac-seceng
+            - snyk-cloud-dev-ex
           requires:
             - Lint & formatting
           <<: *only_feature_branch


### PR DESCRIPTION
### What this does

Replace context used for cicd checks with one owned by our team.

### Notes for the reviewer

-

### More information

- [Jira ticket CFG-2379](https://snyksec.atlassian.net/browse/CFG-2379)
