### PR TITLE
chore: add gitleaks pre-commit hook [CFG-2425]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
### What this does

Setups the gitleaks pre-commit hook for this repository.

### More Information

- JIRA ticket: [CFG-2425](https://snyksec.atlassian.net/browse/CFG-2425)

[CFG-2425]: https://snyksec.atlassian.net/browse/CFG-2425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ